### PR TITLE
Remove generate id in `UIAwesome\Html\FormControl\Button` class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.1.1 Under development
 
+- Bug #4: Remove generate id in `UIAwesome\Html\FormControl\Button` class (@terabytesoftw)
+
 ## 0.1.0 March 6, 2024
 
 - Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.1 Under development
 
-- Bug #4: Remove generate id in `UIAwesome\Html\FormControl\Button` class (@terabytesoftw)
+- Bug #6: Remove generate id in `UIAwesome\Html\FormControl\Button` class (@terabytesoftw)
 
 ## 0.1.0 March 6, 2024
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
-        "enshrined/svg-sanitize": "^0.17.0",
+        "enshrined/svg-sanitize": "^0.18",
         "php-forge/awesome-widget": "^0.1.2",
         "ui-awesome/html-attribute": "^0.1",
         "ui-awesome/html-concern": "^0.1",

--- a/src/FormControl/Button.php
+++ b/src/FormControl/Button.php
@@ -81,7 +81,6 @@ final class Button extends Element
     protected function loadDefaultDefinitions(): array
     {
         return [
-            'id()' => [Utils::generateId('button-')],
             'template()' => ['{prefix}\n{tag}\n{suffix}'],
             'tagName()' => ['button'],
         ];

--- a/tests/FormControl/Button/AttributeTest.php
+++ b/tests/FormControl/Button/AttributeTest.php
@@ -162,11 +162,6 @@ final class AttributeTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGenerateId(): void
-    {
-        $this->assertStringContainsString('<button id="button-', Button::widget()->render());
-    }
-
     public function testId(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
