### PR TITLE
feat(list): Add `Dl`, `Dt`, and `Dd` class tag for list support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.0 Under development
 
 - Enh #16: Refactor codebase to improve performance (@terabytesoftw)
+- Enh #17: Add `Dl`, `Dt`, and `Dd` class tag for list support (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ echo Div::tag()->html('<strong>raw</strong>')->render();
 Create ordered lists, unordered lists, and description lists with a fluent API.
 
 ```php
-use UIAwesome\Html\List\{Dl, Dt, Dd, Ol, Ul, Li};
+use UIAwesome\Html\List\{Dl, Ol, Ul};
 
 // Unordered list with items
 $features = Ul::tag()

--- a/README.md
+++ b/README.md
@@ -94,6 +94,46 @@ echo Div::tag()->html('<strong>raw</strong>')->render();
 // </div>
 ```
 
+#### Powerful list composition
+
+Create ordered lists, unordered lists, and description lists with a fluent API.
+
+```php
+use UIAwesome\Html\List\{Dl, Dt, Dd, Ol, Ul, Li};
+
+// Unordered list with items
+$features = Ul::tag()
+    ->class('feature-list')
+    ->items(
+        'Immutable by design',
+        'Type-safe attributes',
+        'Fluent API',
+        'Standards-compliant',
+    );
+
+// Ordered list with custom start and nested items
+$steps = Ol::tag()
+    ->class('steps')
+    ->start(1)
+    ->reversed(false)
+    ->li('Install with Composer', 1)
+    ->li('Create HTML elements', 2)
+    ->li('Render to string', 3);
+
+// Description list for metadata or glossaries
+$metadata = Dl::tag()
+    ->class('metadata-list')
+    ->dt('Package')
+    ->dd('ui-awesome/html')
+    ->dt('Version')
+    ->dd('0.4.0')
+    ->dt('License')
+    ->dd('BSD-3-Clause');
+
+// Render all lists
+$html = $features->render() . PHP_EOL . $steps->render() . PHP_EOL . $metadata->render();
+```
+
 ## Documentation
 
 For detailed configuration options and advanced usage.

--- a/src/List/Dd.php
+++ b/src/List/Dd.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\List;
+
+use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Interop\{BlockInterface, Lists};
+
+/**
+ * Represents the HTML `<dd>` element for description details.
+ *
+ * Provides a concrete `<dd>` element implementation that returns `Lists::DD` and inherits block-level rendering and
+ * global attribute support from {@see BaseBlock}.
+ *
+ * The `<dd>` element provides the description, definition, or value for the preceding term (`<dt>`) in a description
+ * list (`<dl>`).
+ *
+ * Key features.
+ * - Container element accepts flow content.
+ * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
+ * - Supports global HTML attributes via {@see BaseBlock}.
+ *
+ * Usage example:
+ * ```php
+ * use UIAwesome\Html\List\Dd;
+ *
+ * echo Dd::tag()
+ *     ->content('Description text')
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
+ * {@see BaseBlock} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class Dd extends BaseBlock
+{
+    /**
+     * Returns the tag enumeration for the `<dd>` element.
+     *
+     * @return BlockInterface Tag enumeration instance for `<dd>`.
+     *
+     * {@see Lists} for valid list-level tags.
+     */
+    protected function getTag(): BlockInterface
+    {
+        return Lists::DD;
+    }
+}

--- a/src/List/Dl.php
+++ b/src/List/Dl.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\List;
+
+use Stringable;
+use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Interop\{BlockInterface, Lists};
+
+/**
+ * Represents the HTML `<dl>` element for description lists.
+ *
+ * Provides a concrete `<dl>` element implementation that returns `Lists::DL` and inherits block-level rendering and
+ * global attribute support from {@see BaseBlock}.
+ *
+ * The `<dl>` element represents a description list. The element encloses a list of groups of terms (specified using the
+ * `<dt>` element) and descriptions (provided by `<dd>` elements).
+ *
+ * Key features.
+ * - Container element accepts `<dt>` and `<dd>` child elements.
+ * - Provides helper methods `dt()` and `dd()` for constructing valid description list markup.
+ * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
+ * - Supports global HTML attributes via {@see BaseBlock}.
+ *
+ * Usage example:
+ * ```php
+ * use UIAwesome\Html\List\Dl;
+ *
+ * echo Dl::tag()
+ *     ->class('my-list')
+ *     ->dt('Term 1')
+ *     ->dd('Description 1')
+ *     ->dt('Term 2')
+ *     ->dd('Description 2')
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
+ * {@see BaseBlock} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class Dl extends BaseBlock
+{
+    /**
+     * Appends a `<dd>` element with the specified content to the description list.
+     *
+     * Creates a new instance with a `<dd>` element appended to the content.
+     *
+     * @param string|Stringable $content Content to place inside the `<dd>` element.
+     *
+     * @return static New instance with the appended description details element.
+     *
+     * Usage example:
+     * ```php
+     * $list = Dl::tag()
+     *     ->dd('Description text');
+     * ```
+     */
+    public function dd(string|Stringable $content): static
+    {
+        $dd = Dd::tag()->content($content);
+
+        return $this->html($dd->render(), PHP_EOL);
+    }
+
+    /**
+     * Appends a `<dt>` element with the specified content to the description list.
+     *
+     * Creates a new instance with a `<dt>` element appended to the content.
+     *
+     * @param string|Stringable $content Content to place inside the `<dt>` element.
+     *
+     * @return static New instance with the appended description term element.
+     *
+     * Usage example:
+     * ```php
+     * $list = Dl::tag()
+     *     ->dt('Term text');
+     * ```
+     */
+    public function dt(string|Stringable $content): static
+    {
+        $dt = Dt::tag()->content($content);
+
+        return $this->html($dt->render(), PHP_EOL);
+    }
+
+    /**
+     * Returns the tag enumeration for the `<dl>` element.
+     *
+     * @return BlockInterface Tag enumeration instance for `<dl>`.
+     *
+     * {@see Lists} for valid list-level tags.
+     */
+    protected function getTag(): BlockInterface
+    {
+        return Lists::DL;
+    }
+}

--- a/src/List/Dt.php
+++ b/src/List/Dt.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\List;
+
+use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Interop\{BlockInterface, Lists};
+
+/**
+ * Represents the HTML `<dt>` element for description terms.
+ *
+ * Provides a concrete `<dt>` element implementation that returns `Lists::DT` and inherits block-level rendering and
+ * global attribute support from {@see BaseBlock}.
+ *
+ * The `<dt>` element specifies a term in a description or definition list, and as such must be used inside a `<dl>`
+ * element. It is usually followed by a `<dd>` element.
+ *
+ * Key features.
+ * - Container element accepts phrasing content.
+ * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
+ * - Supports global HTML attributes via {@see BaseBlock}.
+ *
+ * Usage example:
+ * ```php
+ * use UIAwesome\Html\List\Dt;
+ *
+ * echo Dt::tag()
+ *     ->content('Term text')
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt
+ * {@see BaseBlock} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class Dt extends BaseBlock
+{
+    /**
+     * Returns the tag enumeration for the `<dt>` element.
+     *
+     * @return BlockInterface Tag enumeration instance for `<dt>`.
+     *
+     * {@see Lists} for valid list-level tags.
+     */
+    protected function getTag(): BlockInterface
+    {
+        return Lists::DT;
+    }
+}

--- a/tests/List/DdTest.php
+++ b/tests/List/DdTest.php
@@ -639,7 +639,9 @@ final class DdTest extends TestCase
             <dd title="value">
             </dd>
             HTML,
-            Dd::tag()->title('value')->render(),
+            LineEndingNormalizer::normalize(
+                Dd::tag()->title('value')->render(),
+            ),
             "Failed asserting that element renders correctly with 'title' attribute.",
         );
     }

--- a/tests/List/DdTest.php
+++ b/tests/List/DdTest.php
@@ -1,0 +1,706 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\List;
+
+use PHPForge\Support\LineEndingNormalizer;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{
+    Aria,
+    ContentEditable,
+    Data,
+    Direction,
+    Draggable,
+    GlobalAttribute,
+    Language,
+    Role,
+    Translate,
+};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\List\Dd;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see Dd} `<dd>` behavior.
+ *
+ * Verifies rendered output, attribute handling, configuration precedence, and content encoding for {@see Dd::tag()}.
+ *
+ * Test coverage.
+ * - Applies global `aria-*` and `data-*` attributes via helper methods.
+ * - Applies global defaults and theme providers via {@see SimpleFactory} and provider stubs.
+ * - Renders content, `begin()`/`end()`, and string casting.
+ *
+ * {@see Dd} for implementation details.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('html')]
+#[Group('list')]
+final class DdTest extends TestCase
+{
+    public function testContentEncodesValues(): void
+    {
+        $dd = Dd::tag()->content('<value>');
+
+        self::assertSame(
+            '&lt;value&gt;',
+            $dd->getContent(),
+            "Failed asserting that 'content()' method encodes values correctly.",
+        );
+    }
+
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'default',
+            Dd::tag()->getAttribute('data-test', 'default'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testGetAttributesReturnsAssignedAttributes(): void
+    {
+        self::assertSame(
+            ['data-test' => 'value'],
+            Dd::tag()->addAttribute('data-test', 'value')->getAttributes(),
+            "Failed asserting that 'getAttributes()' returns the assigned attributes.",
+        );
+    }
+
+    public function testHtmlDoesNotEncodeValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd>
+            <value>
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->html('<value>')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'html()' method.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd accesskey="k">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->accesskey('k')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd aria-pressed="true">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->addAriaAttribute('pressed', true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd aria-pressed="true">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->addAriaAttribute(Aria::PRESSED, true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd data-test="value">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->addAttribute('data-test', 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd title="value">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->addAttribute(GlobalAttribute::TITLE, 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd data-value="value">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->addDataAttribute('value', 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd data-value="value">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->addDataAttribute(Data::VALUE, 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd aria-controls="modal-1" aria-hidden="false" aria-label="Close">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()
+                    ->ariaAttributes(
+                        [
+                            'controls' => static fn(): string => 'modal-1',
+                            'hidden' => false,
+                            'label' => 'Close',
+                        ],
+                    )
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd class="value">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->attributes(['class' => 'value'])->render(),
+            ),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd autofocus>
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->autofocus(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'autofocus' attribute.",
+        );
+    }
+
+    public function testRenderWithBeginEnd(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd>
+            Content
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->begin() . 'Content' . Dd::end(),
+            ),
+            "Failed asserting that element renders correctly with 'begin()' and 'end()' methods.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd class="value">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->class('value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithContent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd>
+            value
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->content('value')->render(),
+            ),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithContentEditable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd contenteditable="true">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->contentEditable(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute.",
+        );
+    }
+
+    public function testRenderWithContentEditableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd contenteditable="true">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->contentEditable(ContentEditable::TRUE)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd data-value="value">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->dataAttributes(['value' => 'value'])->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd class="default-class">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag(['class' => 'default-class'])->render(),
+            ),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd class="default-class" title="default-title">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->addDefaultProvider(DefaultProvider::class)->render(),
+            ),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd dir="ltr">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->dir('ltr')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd dir="ltr">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->dir(Direction::LTR)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dir' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithDraggable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd draggable="true">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->draggable(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'draggable' attribute.",
+        );
+    }
+
+    public function testRenderWithDraggableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd draggable="true">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->draggable(Draggable::TRUE)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'draggable' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(Dd::class, ['class' => 'default-class']);
+
+        self::assertSame(
+            <<<HTML
+            <dd class="default-class">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->render(),
+            ),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(Dd::class, []);
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd hidden>
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->hidden(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd id="test-id">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->id('test-id')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd lang="es">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->lang('es')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd lang="es">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->lang(Language::SPANISH)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithMicroData(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd itemid="https://example.com/item" itemprop="name" itemref="info" itemscope itemtype="https://schema.org/Thing">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()
+                    ->itemId('https://example.com/item')
+                    ->itemProp('name')
+                    ->itemRef('info')
+                    ->itemScope(true)
+                    ->itemType('https://schema.org/Thing')
+                    ->render(),
+            ),
+            'Failed asserting that element renders correctly with microdata attributes.',
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd>
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()
+                    ->addAriaAttribute('label', 'Close')
+                    ->removeAriaAttribute('label')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd>
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()
+                    ->addAttribute('data-test', 'value')
+                    ->removeAttribute('data-test')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd>
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()
+                    ->addDataAttribute('value', 'test')
+                    ->removeDataAttribute('value')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd role="definition">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->role('definition')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd role="definition">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->role(Role::DEFINITION)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithSpellcheck(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd spellcheck="true">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->spellcheck(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'spellcheck' attribute.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd style='value'>
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->style('value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd tabindex="3">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->tabIndex(3)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd class="text-muted">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->addThemeProvider('muted', DefaultThemeProvider::class)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd title="value">
+            </dd>
+            HTML,
+            Dd::tag()->title('value')->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd>
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                (string) Dd::tag(),
+            ),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd translate="no">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->translate(false)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dd translate="no">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag()->translate(Translate::NO)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'translate' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(Dd::class, ['class' => 'from-global', 'id' => 'id-global']);
+
+        self::assertSame(
+            <<<HTML
+            <dd class="from-global" id="id-user">
+            </dd>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dd::tag(['id' => 'id-user'])->render(),
+            ),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(Dd::class, []);
+    }
+}

--- a/tests/List/DlTest.php
+++ b/tests/List/DlTest.php
@@ -1,0 +1,784 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\List;
+
+use PHPForge\Support\LineEndingNormalizer;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{
+    Aria,
+    ContentEditable,
+    Data,
+    Direction,
+    Draggable,
+    GlobalAttribute,
+    Language,
+    Role,
+    Translate,
+};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\List\Dl;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see Dl} `<dl>` behavior.
+ *
+ * Verifies rendered output, attribute handling, configuration precedence, content encoding, and description list item
+ * helpers for {@see Dl::tag()}.
+ *
+ * Test coverage.
+ * - Applies global `aria-*` and `data-*` attributes via helper methods.
+ * - Applies global defaults and theme providers via {@see SimpleFactory} and provider stubs.
+ * - Renders content, `begin()`/`end()`, and string casting.
+ * - Renders description terms via `dt()` and description details via `dd()` helper methods.
+ *
+ * {@see Dl} for implementation details.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('html')]
+#[Group('list')]
+final class DlTest extends TestCase
+{
+    public function testContentEncodesValues(): void
+    {
+        $dl = Dl::tag()->content('<value>');
+
+        self::assertSame(
+            '&lt;value&gt;',
+            $dl->getContent(),
+            "Failed asserting that 'content()' method encodes values correctly.",
+        );
+    }
+
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'default',
+            Dl::tag()->getAttribute('data-test', 'default'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testGetAttributesReturnsAssignedAttributes(): void
+    {
+        self::assertSame(
+            ['data-test' => 'value'],
+            Dl::tag()->addAttribute('data-test', 'value')->getAttributes(),
+            "Failed asserting that 'getAttributes()' returns the assigned attributes.",
+        );
+    }
+
+    public function testHtmlDoesNotEncodeValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl>
+            <value>
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->html('<value>')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'html()' method.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl accesskey="k">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->accesskey('k')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl aria-pressed="true">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->addAriaAttribute('pressed', true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl aria-pressed="true">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->addAriaAttribute(Aria::PRESSED, true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl data-test="value">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->addAttribute('data-test', 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl title="value">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->addAttribute(GlobalAttribute::TITLE, 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl data-value="value">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->addDataAttribute('value', 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl data-value="value">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->addDataAttribute(Data::VALUE, 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl aria-controls="modal-1" aria-hidden="false" aria-label="Close">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()
+                    ->ariaAttributes(
+                        [
+                            'controls' => static fn(): string => 'modal-1',
+                            'hidden' => false,
+                            'label' => 'Close',
+                        ],
+                    )
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl class="value">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->attributes(['class' => 'value'])->render(),
+            ),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl autofocus>
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->autofocus(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'autofocus' attribute.",
+        );
+    }
+
+    public function testRenderWithBeginEnd(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl>
+            Content
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->begin() . 'Content' . Dl::end(),
+            ),
+            "Failed asserting that element renders correctly with 'begin()' and 'end()' methods.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl class="value">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->class('value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithContent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl>
+            value
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->content('value')->render(),
+            ),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithContentEditable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl contenteditable="true">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->contentEditable(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute.",
+        );
+    }
+
+    public function testRenderWithContentEditableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl contenteditable="true">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->contentEditable(ContentEditable::TRUE)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl data-value="value">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->dataAttributes(['value' => 'value'])->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDd(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl>
+            <dd>
+            First description
+            </dd>
+            <dd>
+            Second description
+            </dd>
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->dd('First description')->dd('Second description')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dd()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl class="default-class">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag(['class' => 'default-class'])->render(),
+            ),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl class="default-class" title="default-title">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->addDefaultProvider(DefaultProvider::class)->render(),
+            ),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl dir="ltr">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->dir('ltr')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl dir="ltr">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->dir(Direction::LTR)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dir' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithDraggable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl draggable="true">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->draggable(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'draggable' attribute.",
+        );
+    }
+
+    public function testRenderWithDraggableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl draggable="true">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->draggable(Draggable::TRUE)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'draggable' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithDt(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl>
+            <dt>
+            First term
+            </dt>
+            <dt>
+            Second term
+            </dt>
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->dt('First term')->dt('Second term')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dt()' method.",
+        );
+    }
+
+    public function testRenderWithDtAndDd(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl>
+            <dt>
+            Term
+            </dt>
+            <dd>
+            Description
+            </dd>
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->dt('Term')->dd('Description')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dt()' and 'dd()' methods.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(Dl::class, ['class' => 'default-class']);
+
+        self::assertSame(
+            <<<HTML
+            <dl class="default-class">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->render(),
+            ),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(Dl::class, []);
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl hidden>
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->hidden(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl id="test-id">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->id('test-id')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl lang="es">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->lang('es')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl lang="es">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->lang(Language::SPANISH)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithMicroData(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl itemid="https://example.com/item" itemprop="name" itemref="info" itemscope itemtype="https://schema.org/Thing">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()
+                    ->itemId('https://example.com/item')
+                    ->itemProp('name')
+                    ->itemRef('info')
+                    ->itemScope(true)
+                    ->itemType('https://schema.org/Thing')
+                    ->render(),
+            ),
+            'Failed asserting that element renders correctly with microdata attributes.',
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl>
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()
+                    ->addAriaAttribute('label', 'Close')
+                    ->removeAriaAttribute('label')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl>
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()
+                    ->addAttribute('data-test', 'value')
+                    ->removeAttribute('data-test')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl>
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()
+                    ->addDataAttribute('value', 'test')
+                    ->removeDataAttribute('value')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl role="list">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->role('list')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl role="list">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->role(Role::LIST)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithSpellcheck(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl spellcheck="true">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->spellcheck(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'spellcheck' attribute.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl style='value'>
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->style('value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl tabindex="3">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->tabIndex(3)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl class="text-muted">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->addThemeProvider('muted', DefaultThemeProvider::class)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl title="value">
+            </dl>
+            HTML,
+            Dl::tag()->title('value')->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl>
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                (string) Dl::tag(),
+            ),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl translate="no">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->translate(false)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dl translate="no">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag()->translate(Translate::NO)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'translate' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(Dl::class, ['class' => 'from-global', 'id' => 'id-global']);
+
+        self::assertSame(
+            <<<HTML
+            <dl class="from-global" id="id-user">
+            </dl>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dl::tag(['id' => 'id-user'])->render(),
+            ),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(Dl::class, []);
+    }
+
+    public function testReturnNewInstanceWhenSettingAttribute(): void
+    {
+        $dl = Dl::tag();
+
+        self::assertNotSame(
+            $dl,
+            $dl->dt(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $dl,
+            $dl->dd(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+}

--- a/tests/List/DlTest.php
+++ b/tests/List/DlTest.php
@@ -701,7 +701,9 @@ final class DlTest extends TestCase
             <dl title="value">
             </dl>
             HTML,
-            Dl::tag()->title('value')->render(),
+            LineEndingNormalizer::normalize(
+                Dl::tag()->title('value')->render(),
+            ),
             "Failed asserting that element renders correctly with 'title' attribute.",
         );
     }

--- a/tests/List/DtTest.php
+++ b/tests/List/DtTest.php
@@ -1,0 +1,706 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\List;
+
+use PHPForge\Support\LineEndingNormalizer;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{
+    Aria,
+    ContentEditable,
+    Data,
+    Direction,
+    Draggable,
+    GlobalAttribute,
+    Language,
+    Role,
+    Translate,
+};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\List\Dt;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see Dt} `<dt>` behavior.
+ *
+ * Verifies rendered output, attribute handling, configuration precedence, and content encoding for {@see Dt::tag()}.
+ *
+ * Test coverage.
+ * - Applies global `aria-*` and `data-*` attributes via helper methods.
+ * - Applies global defaults and theme providers via {@see SimpleFactory} and provider stubs.
+ * - Renders content, `begin()`/`end()`, and string casting.
+ *
+ * {@see Dt} for implementation details.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('html')]
+#[Group('list')]
+final class DtTest extends TestCase
+{
+    public function testContentEncodesValues(): void
+    {
+        $dt = Dt::tag()->content('<value>');
+
+        self::assertSame(
+            '&lt;value&gt;',
+            $dt->getContent(),
+            "Failed asserting that 'content()' method encodes values correctly.",
+        );
+    }
+
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'default',
+            Dt::tag()->getAttribute('data-test', 'default'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testGetAttributesReturnsAssignedAttributes(): void
+    {
+        self::assertSame(
+            ['data-test' => 'value'],
+            Dt::tag()->addAttribute('data-test', 'value')->getAttributes(),
+            "Failed asserting that 'getAttributes()' returns the assigned attributes.",
+        );
+    }
+
+    public function testHtmlDoesNotEncodeValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt>
+            <value>
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->html('<value>')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'html()' method.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt accesskey="k">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->accesskey('k')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt aria-pressed="true">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->addAriaAttribute('pressed', true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt aria-pressed="true">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->addAriaAttribute(Aria::PRESSED, true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt data-test="value">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->addAttribute('data-test', 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt title="value">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->addAttribute(GlobalAttribute::TITLE, 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt data-value="value">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->addDataAttribute('value', 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt data-value="value">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->addDataAttribute(Data::VALUE, 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt aria-controls="modal-1" aria-hidden="false" aria-label="Close">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()
+                    ->ariaAttributes(
+                        [
+                            'controls' => static fn(): string => 'modal-1',
+                            'hidden' => false,
+                            'label' => 'Close',
+                        ],
+                    )
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt class="value">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->attributes(['class' => 'value'])->render(),
+            ),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt autofocus>
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->autofocus(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'autofocus' attribute.",
+        );
+    }
+
+    public function testRenderWithBeginEnd(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt>
+            Content
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->begin() . 'Content' . Dt::end(),
+            ),
+            "Failed asserting that element renders correctly with 'begin()' and 'end()' methods.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt class="value">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->class('value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithContent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt>
+            value
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->content('value')->render(),
+            ),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithContentEditable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt contenteditable="true">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->contentEditable(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute.",
+        );
+    }
+
+    public function testRenderWithContentEditableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt contenteditable="true">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->contentEditable(ContentEditable::TRUE)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt data-value="value">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->dataAttributes(['value' => 'value'])->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt class="default-class">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag(['class' => 'default-class'])->render(),
+            ),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt class="default-class" title="default-title">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->addDefaultProvider(DefaultProvider::class)->render(),
+            ),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt dir="ltr">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->dir('ltr')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt dir="ltr">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->dir(Direction::LTR)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dir' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithDraggable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt draggable="true">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->draggable(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'draggable' attribute.",
+        );
+    }
+
+    public function testRenderWithDraggableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt draggable="true">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->draggable(Draggable::TRUE)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'draggable' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(Dt::class, ['class' => 'default-class']);
+
+        self::assertSame(
+            <<<HTML
+            <dt class="default-class">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->render(),
+            ),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(Dt::class, []);
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt hidden>
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->hidden(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt id="test-id">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->id('test-id')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt lang="es">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->lang('es')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt lang="es">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->lang(Language::SPANISH)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithMicroData(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt itemid="https://example.com/item" itemprop="name" itemref="info" itemscope itemtype="https://schema.org/Thing">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()
+                    ->itemId('https://example.com/item')
+                    ->itemProp('name')
+                    ->itemRef('info')
+                    ->itemScope(true)
+                    ->itemType('https://schema.org/Thing')
+                    ->render(),
+            ),
+            'Failed asserting that element renders correctly with microdata attributes.',
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt>
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()
+                    ->addAriaAttribute('label', 'Close')
+                    ->removeAriaAttribute('label')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt>
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()
+                    ->addAttribute('data-test', 'value')
+                    ->removeAttribute('data-test')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt>
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()
+                    ->addDataAttribute('value', 'test')
+                    ->removeDataAttribute('value')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt role="listitem">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->role('listitem')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt role="listitem">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->role(Role::LISTITEM)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithSpellcheck(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt spellcheck="true">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->spellcheck(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'spellcheck' attribute.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt style='value'>
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->style('value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt tabindex="3">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->tabIndex(3)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt class="text-muted">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->addThemeProvider('muted', DefaultThemeProvider::class)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt title="value">
+            </dt>
+            HTML,
+            Dt::tag()->title('value')->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt>
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                (string) Dt::tag(),
+            ),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt translate="no">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->translate(false)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <dt translate="no">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag()->translate(Translate::NO)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'translate' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(Dt::class, ['class' => 'from-global', 'id' => 'id-global']);
+
+        self::assertSame(
+            <<<HTML
+            <dt class="from-global" id="id-user">
+            </dt>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Dt::tag(['id' => 'id-user'])->render(),
+            ),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(Dt::class, []);
+    }
+}

--- a/tests/List/DtTest.php
+++ b/tests/List/DtTest.php
@@ -639,7 +639,9 @@ final class DtTest extends TestCase
             <dt title="value">
             </dt>
             HTML,
-            Dt::tag()->title('value')->render(),
+            LineEndingNormalizer::normalize(
+                Dt::tag()->title('value')->render(),
+            ),
             "Failed asserting that element renders correctly with 'title' attribute.",
         );
     }

--- a/tests/List/LiTest.php
+++ b/tests/List/LiTest.php
@@ -656,7 +656,9 @@ final class LiTest extends TestCase
             <li title="value">
             </li>
             HTML,
-            Li::tag()->title('value')->render(),
+            LineEndingNormalizer::normalize(
+                Li::tag()->title('value')->render(),
+            ),
             "Failed asserting that element renders correctly with 'title' attribute.",
         );
     }

--- a/tests/List/OlTest.php
+++ b/tests/List/OlTest.php
@@ -738,7 +738,9 @@ final class OlTest extends TestCase
             <ol title="value">
             </ol>
             HTML,
-            Ol::tag()->title('value')->render(),
+            LineEndingNormalizer::normalize(
+                Ol::tag()->title('value')->render(),
+            ),
             "Failed asserting that element renders correctly with 'title' attribute.",
         );
     }

--- a/tests/List/OlTest.php
+++ b/tests/List/OlTest.php
@@ -522,6 +522,23 @@ final class OlTest extends TestCase
         );
     }
 
+    public function testRenderWithLiValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <ol>
+            <li value="3">
+            Item
+            </li>
+            </ol>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Ol::tag()->li('Item', 3)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'li()' method using a value.",
+        );
+    }
+
     public function testRenderWithMicroData(): void
     {
         self::assertSame(

--- a/tests/List/UlTest.php
+++ b/tests/List/UlTest.php
@@ -522,6 +522,23 @@ final class UlTest extends TestCase
         );
     }
 
+    public function testRenderWithLiValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <ul>
+            <li value="3">
+            Item
+            </li>
+            </ul>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Ul::tag()->li('Item', 3)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'li()' method using a value.",
+        );
+    }
+
     public function testRenderWithMicroData(): void
     {
         self::assertSame(

--- a/tests/List/UlTest.php
+++ b/tests/List/UlTest.php
@@ -684,7 +684,9 @@ final class UlTest extends TestCase
             <ul title="value">
             </ul>
             HTML,
-            Ul::tag()->title('value')->render(),
+            LineEndingNormalizer::normalize(
+                Ul::tag()->title('value')->render(),
+            ),
             "Failed asserting that element renders correctly with 'title' attribute.",
         );
     }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added description-list support (dl, dt, dd) with a fluent API for composing chained list elements.

* **Documentation**
  * Added a "Powerful list composition" section with examples.
  * Updated changelog with the new list support entry.

* **Tests**
  * Added comprehensive test suites validating rendering, attributes, composition, and line-ending normalization for list elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->