### PR TITLE
fix(docs): Standardize PHPDoc headers and usage examples across core HTML elements in `src`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enh #16: Refactor codebase to improve performance (@terabytesoftw)
 - Enh #17: Add `Dl`, `Dt`, and `Dd` class tag for list support (@terabytesoftw)
 - Enh #18: Add `InputWeek` class for HTML `<input type="week">` element with attributes and rendering capabilities (@terabytesoftw)
+- Bug #19: Standardize PHPDoc headers and usage examples across core HTML elements in `src` (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Embedded/Attribute/HasElementtiming.php
+++ b/src/Embedded/Attribute/HasElementtiming.php
@@ -7,17 +7,7 @@ namespace UIAwesome\Html\Embedded\Attribute;
 use UnitEnum;
 
 /**
- * Trait for managing the HTML `elementtiming` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `elementtiming` attribute on HTML elements.
- *
- * Intended for use in tags and components that require manipulation of the `elementtiming` attribute.
- *
- * Key features.
- * - Designed for use in image elements (img) requiring performance observation.
- * - Handles the HTML `elementtiming` attribute.
- * - Immutable method for setting or overriding the `elementtiming` attribute.
- * - Supports string and `null` for flexible element timing identifier assignment.
+ * Provides an immutable API for the HTML `elementtiming` attribute.
  *
  * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -30,25 +20,17 @@ use UnitEnum;
 trait HasElementtiming
 {
     /**
-     * Sets the HTML `elementtiming` attribute for the element.
+     * Sets the `elementtiming` attribute.
      *
-     * Creates a new instance with the specified element timing identifier value, supporting explicit assignment
-     * according to the HTML specification for performance observation.
-     *
-     * The `elementtiming` attribute marks the element for observation by the PerformanceElementTiming API. When set,
-     * the browser will record timing information about the element's rendering, which can be accessed via the
-     * PerformanceObserver API. This is useful for measuring performance of important page elements.
-     *
-     * @param string|UnitEnum|null $value Element timing identifier to set for the element. Use a descriptive string
-     * identifier (for example, "hero-image"). Can be `null` to unset the attribute.
+     * @param string|UnitEnum|null $value Element timing identifier, or `null` to remove the attribute.
      *
      * @return static New instance with the updated `elementtiming` attribute.
      *
      * Usage example:
      * ```php
-     * $element->elementtiming('hero-image');
-     * $element->elementtiming('product-thumbnail');
-     * $element->elementtiming(null);
+     * echo \UIAwesome\Html\Embedded\Img::tag()->elementtiming('hero-image')->render();
+     * echo \UIAwesome\Html\Embedded\Img::tag()->elementtiming('product-thumbnail')->render();
+     * echo \UIAwesome\Html\Embedded\Img::tag()->elementtiming(null)->render();
      * ```
      */
     public function elementtiming(string|UnitEnum|null $value): static

--- a/src/Embedded/Attribute/HasElementtiming.php
+++ b/src/Embedded/Attribute/HasElementtiming.php
@@ -22,16 +22,16 @@ trait HasElementtiming
     /**
      * Sets the `elementtiming` attribute.
      *
-     * @param string|UnitEnum|null $value Element timing identifier, or `null` to remove the attribute.
-     *
-     * @return static New instance with the updated `elementtiming` attribute.
-     *
      * Usage example:
      * ```php
      * echo \UIAwesome\Html\Embedded\Img::tag()->elementtiming('hero-image')->render();
      * echo \UIAwesome\Html\Embedded\Img::tag()->elementtiming('product-thumbnail')->render();
      * echo \UIAwesome\Html\Embedded\Img::tag()->elementtiming(null)->render();
      * ```
+     *
+     * @param string|UnitEnum|null $value Element timing identifier, or `null` to remove the attribute.
+     *
+     * @return static New instance with the updated `elementtiming` attribute.
      */
     public function elementtiming(string|UnitEnum|null $value): static
     {

--- a/src/Embedded/Attribute/HasIsmap.php
+++ b/src/Embedded/Attribute/HasIsmap.php
@@ -20,14 +20,14 @@ trait HasIsmap
     /**
      * Sets the `ismap` attribute.
      *
-     * @param bool $value Whether the image is a server-side image map.
-     *
-     * @return static New instance with the updated `ismap` attribute.
-     *
      * Usage example:
      * ```php
      * echo \UIAwesome\Html\Embedded\Img::tag()->ismap(true)->render();
      * ```
+     *
+     * @param bool $value Whether the image is a server-side image map.
+     *
+     * @return static New instance with the updated `ismap` attribute.
      */
     public function ismap(bool $value): static
     {

--- a/src/Embedded/Attribute/HasIsmap.php
+++ b/src/Embedded/Attribute/HasIsmap.php
@@ -5,14 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Embedded\Attribute;
 
 /**
- * Trait for managing the HTML `ismap` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `ismap` attribute on `<img>` elements.
- *
- * Key features.
- * - Handles the HTML `ismap` attribute for server-side image maps.
- * - Immutable method for setting or overriding the `ismap` attribute.
- * - Supports bool for explicit server-side image map control.
+ * Provides an immutable API for the HTML `ismap` attribute.
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -25,16 +18,16 @@ namespace UIAwesome\Html\Embedded\Attribute;
 trait HasIsmap
 {
     /**
-     * Sets the HTML `ismap` attribute for the element.
-     *
-     * Creates a new instance with the specified ismap value.
-     *
-     * When `true`, the image is part of a server-side image map. This attribute is only permitted if the `<img>`
-     * element is a descendant of an `<a>` element with a valid `href` attribute.
+     * Sets the `ismap` attribute.
      *
      * @param bool $value Whether the image is a server-side image map.
      *
      * @return static New instance with the updated `ismap` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Embedded\Img::tag()->ismap(true)->render();
+     * ```
      */
     public function ismap(bool $value): static
     {

--- a/src/Embedded/Img.php
+++ b/src/Embedded/Img.php
@@ -21,24 +21,11 @@ use UIAwesome\Html\Embedded\Attribute\{HasElementtiming, HasIsmap};
 use UIAwesome\Html\Interop\{VoidInterface, Voids};
 
 /**
- * Represents the HTML `<img>` element for embedding images.
- *
- * Provides a concrete `<img>` element implementation that returns `Voids::IMG` and inherits void-level rendering and
- * global attribute support from {@see BaseVoid}.
- *
- * The `<img>` element embeds an image into the document.
- *
- * Key features.
- * - Supports global HTML attributes via {@see BaseVoid}.
- * - Supports image-specific attributes: `alt`, `src`, `srcset`, `sizes`, `width`, `height`, `loading`, `decoding`,
- *   `crossorigin`, `fetchpriority`, `referrerpolicy`, `ismap`, `usemap`, and `elementtiming`.
- * - Void element renders without end tag.
+ * Renders the HTML `<img>` element for embedding images.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Embedded\Img;
- *
- * echo Img::tag()
+ * echo \UIAwesome\Html\Embedded\Img::tag()
  *     ->src('image.jpg')
  *     ->alt('A beautiful landscape')
  *     ->width(800)

--- a/src/Flow/Div.php
+++ b/src/Flow/Div.php
@@ -8,23 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<div>` element for grouping flow content.
- *
- * Provides a concrete `<div>` element implementation that returns `Block::DIV` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<div>` element is a generic container with no semantic meaning.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<div>` element for grouping flow content.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Flow\Div;
- *
- * echo Div::tag()
+ * echo \UIAwesome\Html\Flow\Div::tag()
  *     ->class('container')
  *     ->content('value')
  *     ->render();

--- a/src/Flow/Hr.php
+++ b/src/Flow/Hr.php
@@ -8,22 +8,11 @@ use UIAwesome\Html\Core\Element\BaseVoid;
 use UIAwesome\Html\Interop\{VoidInterface, Voids};
 
 /**
- * Represents the HTML `<hr>` element for thematic breaks.
- *
- * Provides a concrete `<hr>` element implementation that returns `Voids::HR` and inherits void-level rendering and
- * global attribute support from {@see BaseVoid}.
- *
- * The `<hr>` element represents a thematic break between paragraph-level elements.
- *
- * Key features.
- * - Supports global HTML attributes via {@see BaseVoid}.
- * - Void element renders without end tag.
+ * Renders the HTML `<hr>` element for thematic breaks.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Flow\Hr;
- *
- * echo Hr::tag()
+ * echo \UIAwesome\Html\Flow\Hr::tag()
  *     ->class('divider')
  *     ->render();
  * ```

--- a/src/Flow/Main.php
+++ b/src/Flow/Main.php
@@ -8,23 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<main>` element for dominant document content.
- *
- * Provides a concrete `<main>` element implementation that returns `Block::MAIN` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<main>` element represents the dominant content of the document.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<main>` element for dominant document content.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Flow\Main;
- *
- * echo Main::tag()
+ * echo \UIAwesome\Html\Flow\Main::tag()
  *     ->class('content')
  *     ->content('value')
  *     ->render();

--- a/src/Flow/P.php
+++ b/src/Flow/P.php
@@ -8,23 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<p>` element for grouping paragraphs of text.
- *
- * Provides a concrete `<p>` element implementation that returns `Block::P` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<p>` element represents a paragraph of text.
- *
- * Key features.
- * - Paragraph element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<p>` element for paragraphs.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Flow\P;
- *
- * echo P::tag()
+ * echo \UIAwesome\Html\Flow\P::tag()
  *     ->class('lead')
  *     ->content('Hello')
  *     ->render();

--- a/src/Heading/H1.php
+++ b/src/Heading/H1.php
@@ -8,24 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<h1>` element for the highest section heading.
- *
- * Provides a concrete `<h1>` element implementation that returns `Block::H1` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<h1>` element represents the highest level of section headings. `<h1>` is the highest section level and `<h6>`
- * is the lowest. By default, all heading elements create a block-level box in the layout.
- *
- * Key features.
- * - Accepts phrasing content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<h1>` element for top-level section headings.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Heading\H1;
- *
- * echo H1::tag()
+ * echo \UIAwesome\Html\Heading\H1::tag()
  *     ->class('main-title')
  *     ->content('Main Title')
  *     ->render();

--- a/src/Heading/H2.php
+++ b/src/Heading/H2.php
@@ -8,24 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<h2>` element for section headings.
- *
- * Provides a concrete `<h2>` element implementation that returns `Block::H2` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<h2>` element represents the second level of section headings. `<h1>` is the highest section level and `<h6>` is
- * the lowest. By default, all heading elements create a block-level box in the layout.
- *
- * Key features.
- * - Accepts phrasing content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<h2>` element for second-level section headings.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Heading\H2;
- *
- * echo H2::tag()
+ * echo \UIAwesome\Html\Heading\H2::tag()
  *     ->class('section-title')
  *     ->content('Section Title')
  *     ->render();

--- a/src/Heading/H3.php
+++ b/src/Heading/H3.php
@@ -8,24 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<h3>` element for section headings.
- *
- * Provides a concrete `<h3>` element implementation that returns `Block::H3` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<h3>` element represents the third level of section headings. `<h1>` is the highest section level and `<h6>` is
- * the lowest. By default, all heading elements create a block-level box in the layout.
- *
- * Key features.
- * - Accepts phrasing content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<h3>` element for third-level section headings.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Heading\H3;
- *
- * echo H3::tag()
+ * echo \UIAwesome\Html\Heading\H3::tag()
  *     ->class('subsection-title')
  *     ->content('Subsection Title')
  *     ->render();

--- a/src/Heading/H4.php
+++ b/src/Heading/H4.php
@@ -8,24 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<h4>` element for section headings.
- *
- * Provides a concrete `<h4>` element implementation that returns `Block::H4` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<h4>` element represents the fourth level of section headings. `<h1>` is the highest section level and `<h6>` is
- * the lowest. By default, all heading elements create a block-level box in the layout.
- *
- * Key features.
- * - Accepts phrasing content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<h4>` element for fourth-level section headings.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Heading\H4;
- *
- * echo H4::tag()
+ * echo \UIAwesome\Html\Heading\H4::tag()
  *     ->class('subsection-title')
  *     ->content('Subsection Title')
  *     ->render();

--- a/src/Heading/H5.php
+++ b/src/Heading/H5.php
@@ -8,24 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<h5>` element for section headings.
- *
- * Provides a concrete `<h5>` element implementation that returns `Block::H5` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<h5>` element represents the fifth level of section headings. `<h1>` is the highest section level and `<h6>` is
- * the lowest. By default, all heading elements create a block-level box in the layout.
- *
- * Key features.
- * - Accepts phrasing content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<h5>` element for fifth-level section headings.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Heading\H5;
- *
- * echo H5::tag()
+ * echo \UIAwesome\Html\Heading\H5::tag()
  *     ->class('subsection-title')
  *     ->content('Subsection Title')
  *     ->render();

--- a/src/Heading/H6.php
+++ b/src/Heading/H6.php
@@ -8,24 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<h6>` element for the lowest section heading.
- *
- * Provides a concrete `<h6>` element implementation that returns `Block::H6` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<h6>` element represents the sixth and lowest level of section headings. `<h1>` is the highest section level and
- * `<h6>` is the lowest. By default, all heading elements create a block-level box in the layout.
- *
- * Key features.
- * - Accepts phrasing content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<h6>` element for lowest-level section headings.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Heading\H6;
- *
- * echo H6::tag()
+ * echo \UIAwesome\Html\Heading\H6::tag()
  *     ->class('subsection-title')
  *     ->content('Subsection Title')
  *     ->render();

--- a/src/Heading/HGroup.php
+++ b/src/Heading/HGroup.php
@@ -8,29 +8,14 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<hgroup>` element for grouping heading content.
- *
- * Provides a concrete `<hgroup>` element implementation that returns `Block::HGROUP` and inherits block-level rendering
- * and global attribute support from {@see BaseBlock}.
- *
- * The `<hgroup>` element represents a heading and related content. It groups a single `<h1>`–`<h6>` element with one or
- * more `<p>` elements. The element itself has no impact on the document outline.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<hgroup>` element for grouped heading content.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Flow\P;
- * use UIAwesome\Html\Heading\H1;
- * use UIAwesome\Html\Heading\HGroup;
- *
- * echo HGroup::tag()
+ * echo \UIAwesome\Html\Heading\HGroup::tag()
  *     ->content(
- *         H1::tag()->content('Main Title'),
- *         P::tag()->content('Subtitle or tagline')
+ *         \UIAwesome\Html\Heading\H1::tag()->content('Main Title'),
+ *         \UIAwesome\Html\Flow\P::tag()->content('Subtitle or tagline')
  *     )
  *     ->render();
  * ```

--- a/src/List/Attribute/HasReversed.php
+++ b/src/List/Attribute/HasReversed.php
@@ -5,17 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\List\Attribute;
 
 /**
- * Trait for managing the HTML `reversed` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `reversed` attribute on `<ol>` elements.
- *
- * Intended for use in tags and components that require manipulation of the `reversed` attribute.
- *
- * Key features.
- * - Designed for use in ordered list ol elements.
- * - Handles the HTML `reversed` attribute for reverse ordering of list items.
- * - Immutable method for setting or overriding the `reversed` attribute.
- * - Supports bool for explicit reverse ordering control.
+ * Provides an immutable API for the HTML `reversed` attribute.
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -28,18 +18,15 @@ namespace UIAwesome\Html\List\Attribute;
 trait HasReversed
 {
     /**
-     * Sets the HTML `reversed` attribute for the element.
+     * Sets the `reversed` attribute.
      *
-     * Creates a new instance with the specified reversed value. When `true`, the list's items are numbered in reverse
-     * order (from high to low).
-     *
-     * @param bool $value Whether the list items should be in reverse order.
+     * @param bool $value Whether the list items are numbered in reverse order.
      *
      * @return static New instance with the updated `reversed` attribute.
      *
      * Usage example:
      * ```php
-     * $element->reversed(true);
+     * echo \UIAwesome\Html\List\Ol::tag()->reversed(true)->render();
      * ```
      */
     public function reversed(bool $value): static

--- a/src/List/Attribute/HasReversed.php
+++ b/src/List/Attribute/HasReversed.php
@@ -20,14 +20,14 @@ trait HasReversed
     /**
      * Sets the `reversed` attribute.
      *
-     * @param bool $value Whether the list items are numbered in reverse order.
-     *
-     * @return static New instance with the updated `reversed` attribute.
-     *
      * Usage example:
      * ```php
      * echo \UIAwesome\Html\List\Ol::tag()->reversed(true)->render();
      * ```
+     *
+     * @param bool $value Whether the list items are numbered in reverse order.
+     *
+     * @return static New instance with the updated `reversed` attribute.
      */
     public function reversed(bool $value): static
     {

--- a/src/List/Attribute/HasStart.php
+++ b/src/List/Attribute/HasStart.php
@@ -20,15 +20,15 @@ trait HasStart
     /**
      * Sets the `start` attribute.
      *
-     * @param int|null $value Ordinal start value, or `null` to remove the attribute.
-     *
-     * @return static New instance with the updated `start` attribute.
-     *
      * Usage example:
      * ```php
      * echo \UIAwesome\Html\List\Ol::tag()->start(4)->render();
      * echo \UIAwesome\Html\List\Ol::tag()->start(null)->render();
      * ```
+     *
+     * @param int|null $value Ordinal start value, or `null` to remove the attribute.
+     *
+     * @return static New instance with the updated `start` attribute.
      */
     public function start(int|null $value): static
     {

--- a/src/List/Attribute/HasStart.php
+++ b/src/List/Attribute/HasStart.php
@@ -5,17 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\List\Attribute;
 
 /**
- * Trait for managing the HTML `start` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `start` attribute on `<ol>` elements.
- *
- * Intended for use in tags and components that require manipulation of the `start` attribute.
- *
- * Key features.
- * - Designed for use in ordered list ol elements.
- * - Handles the HTML `start` attribute for setting the starting number of list items.
- * - Immutable method for setting or overriding the `start` attribute.
- * - Supports int for explicit starting number assignment.
+ * Provides an immutable API for the HTML `start` attribute.
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -28,19 +18,16 @@ namespace UIAwesome\Html\List\Attribute;
 trait HasStart
 {
     /**
-     * Sets the HTML `start` attribute for the element.
+     * Sets the `start` attribute.
      *
-     * Creates a new instance with the specified start value. The value is always an Arabic numeral (1, 2, 3, etc.),
-     * even when the numbering type is letters or Roman numerals.
-     *
-     * @param int|null $value Integer to start counting from. Can be `null` to unset the attribute.
+     * @param int|null $value Ordinal start value, or `null` to remove the attribute.
      *
      * @return static New instance with the updated `start` attribute.
      *
      * Usage example:
      * ```php
-     * $element->start(4);
-     * $element->start(null);
+     * echo \UIAwesome\Html\List\Ol::tag()->start(4)->render();
+     * echo \UIAwesome\Html\List\Ol::tag()->start(null)->render();
      * ```
      */
     public function start(int|null $value): static

--- a/src/List/Dd.php
+++ b/src/List/Dd.php
@@ -8,24 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{BlockInterface, Lists};
 
 /**
- * Represents the HTML `<dd>` element for description details.
- *
- * Provides a concrete `<dd>` element implementation that returns `Lists::DD` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<dd>` element provides the description, definition, or value for the preceding term (`<dt>`) in a description
- * list (`<dl>`).
- *
- * Key features.
- * - Container element accepts flow content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<dd>` element for description details.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\List\Dd;
- *
- * echo Dd::tag()
+ * echo \UIAwesome\Html\List\Dd::tag()
  *     ->content('Description text')
  *     ->render();
  * ```

--- a/src/List/Dl.php
+++ b/src/List/Dl.php
@@ -9,25 +9,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{BlockInterface, Lists};
 
 /**
- * Represents the HTML `<dl>` element for description lists.
- *
- * Provides a concrete `<dl>` element implementation that returns `Lists::DL` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<dl>` element represents a description list. The element encloses a list of groups of terms (specified using the
- * `<dt>` element) and descriptions (provided by `<dd>` elements).
- *
- * Key features.
- * - Container element accepts `<dt>` and `<dd>` child elements.
- * - Provides helper methods `dt()` and `dd()` for constructing valid description list markup.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<dl>` element for description lists.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\List\Dl;
- *
- * echo Dl::tag()
+ * echo \UIAwesome\Html\List\Dl::tag()
  *     ->class('my-list')
  *     ->dt('Term 1')
  *     ->dd('Description 1')
@@ -45,17 +31,15 @@ use UIAwesome\Html\Interop\{BlockInterface, Lists};
 final class Dl extends BaseBlock
 {
     /**
-     * Appends a `<dd>` element with the specified content to the description list.
+     * Appends a `<dd>` element to the description list.
      *
-     * Creates a new instance with a `<dd>` element appended to the content.
-     *
-     * @param string|Stringable $content Content to place inside the `<dd>` element.
+     * @param string|Stringable $content Content for the `<dd>` element.
      *
      * @return static New instance with the appended description details element.
      *
      * Usage example:
      * ```php
-     * $list = Dl::tag()
+     * $list = \UIAwesome\Html\List\Dl::tag()
      *     ->dd('Description text');
      * ```
      */
@@ -67,17 +51,15 @@ final class Dl extends BaseBlock
     }
 
     /**
-     * Appends a `<dt>` element with the specified content to the description list.
+     * Appends a `<dt>` element to the description list.
      *
-     * Creates a new instance with a `<dt>` element appended to the content.
-     *
-     * @param string|Stringable $content Content to place inside the `<dt>` element.
+     * @param string|Stringable $content Content for the `<dt>` element.
      *
      * @return static New instance with the appended description term element.
      *
      * Usage example:
      * ```php
-     * $list = Dl::tag()
+     * $list = \UIAwesome\Html\List\Dl::tag()
      *     ->dt('Term text');
      * ```
      */

--- a/src/List/Dt.php
+++ b/src/List/Dt.php
@@ -8,24 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{BlockInterface, Lists};
 
 /**
- * Represents the HTML `<dt>` element for description terms.
- *
- * Provides a concrete `<dt>` element implementation that returns `Lists::DT` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<dt>` element specifies a term in a description or definition list, and as such must be used inside a `<dl>`
- * element. It is usually followed by a `<dd>` element.
- *
- * Key features.
- * - Container element accepts phrasing content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<dt>` element for description terms.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\List\Dt;
- *
- * echo Dt::tag()
+ * echo \UIAwesome\Html\List\Dt::tag()
  *     ->content('Term text')
  *     ->render();
  * ```

--- a/src/List/Li.php
+++ b/src/List/Li.php
@@ -9,25 +9,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{BlockInterface, Lists};
 
 /**
- * Represents the HTML `<li>` element for list items.
- *
- * Provides a concrete `<li>` element implementation that returns `Lists::LI` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<li>` element is used to represent an item in a list. It must be contained in a parent element: an ordered list
- * (`<ol>`), an unordered list (`<ul>`), or a menu (`<menu>`).
- *
- * Key features.
- * - Container element accepts flow content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
- * - Supports the `value` attribute for ordered lists.
+ * Renders the HTML `<li>` element for list items.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\List\Li;
- *
- * echo Li::tag()
+ * echo \UIAwesome\Html\List\Li::tag()
  *     ->value(3)
  *     ->content('Third item')
  *     ->render();

--- a/src/List/Ol.php
+++ b/src/List/Ol.php
@@ -64,7 +64,7 @@ final class Ol extends BaseBlock
      * Appends a `<li>` element to the ordered list.
      *
      * @param string|Stringable $content Content for the `<li>` element.
-     * @param string|int|null $value Optional ordinal value for the list item, or `null` to omit the attribute.
+     * @param int|string|null $value Optional ordinal value for the list item, or `null` to omit the attribute.
      *
      * @return static New instance with the appended list item.
      *

--- a/src/List/Ol.php
+++ b/src/List/Ol.php
@@ -10,25 +10,11 @@ use UIAwesome\Html\Interop\{BlockInterface, Lists};
 use UIAwesome\Html\List\Attribute\{HasReversed, HasStart};
 
 /**
- * Represents the HTML `<ol>` element for ordered lists.
- *
- * Provides a concrete `<ol>` element implementation that returns `Lists::OL` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<ol>` element represents an ordered list of items, typically rendered as a numbered list.
- *
- * Key features.
- * - Container element accepts `<li>` child elements.
- * - Provides helper methods `li()` and `items()` for constructing valid list markup.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
- * - Supports ol-specific attributes via helper methods (`reversed`, `start`).
+ * Renders the HTML `<ol>` element for ordered lists.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\List\Ol;
- *
- * echo Ol::tag()
+ * echo \UIAwesome\Html\List\Ol::tag()
  *     ->class('my-list')
  *     ->items('First item', 'Second item', 'Third item')
  *     ->reversed(true)
@@ -48,17 +34,15 @@ final class Ol extends BaseBlock
     use HasStart;
 
     /**
-     * Appends multiple list items to the ordered list.
+     * Appends multiple `<li>` elements to the ordered list.
      *
-     * Creates a new instance with multiple `<li>` elements appended to the content.
-     *
-     * @param string|Stringable ...$items Variable number of items to add as list elements.
+     * @param string|Stringable ...$items Items to add as `<li>` elements.
      *
      * @return static New instance with the appended list items.
      *
      * Usage example:
      * ```php
-     * $list = Ol::tag()->items(
+     * $list = \UIAwesome\Html\List\Ol::tag()->items(
      *     'First step',
      *     'Second step',
      *     'Third step',
@@ -77,22 +61,18 @@ final class Ol extends BaseBlock
     }
 
     /**
-     * Appends a `<li>` element with the specified content to the ordered list.
+     * Appends a `<li>` element to the ordered list.
      *
-     * Creates a new instance with a `<li>` element appended to the content.
-     *
-     * @param string|Stringable $content Content to place inside the `<li>` element.
-     * @param int|string|null $value Optional ordinal value for the list item.
+     * @param string|Stringable $content Content for the `<li>` element.
+     * @param string|int|null $value Optional ordinal value for the list item, or `null` to omit the attribute.
      *
      * @return static New instance with the appended list item.
      *
      * Usage example:
      * ```php
-     * $list = Ol::tag()
-     *     ->li('Item with value', 3);
-     * $list = Ol::tag()
-     *     ->li('First item')
-     *     ->li('Second item');
+     * $list = \UIAwesome\Html\List\Ol::tag()
+     *     ->li('Install dependencies')
+     *     ->li('Run tests', 5);
      * ```
      */
     public function li(string|Stringable $content, string|int|null $value = null): static

--- a/src/List/Ol.php
+++ b/src/List/Ol.php
@@ -36,10 +36,6 @@ final class Ol extends BaseBlock
     /**
      * Appends multiple `<li>` elements to the ordered list.
      *
-     * @param string|Stringable ...$items Items to add as `<li>` elements.
-     *
-     * @return static New instance with the appended list items.
-     *
      * Usage example:
      * ```php
      * $list = \UIAwesome\Html\List\Ol::tag()->items(
@@ -48,6 +44,10 @@ final class Ol extends BaseBlock
      *     'Third step',
      * );
      * ```
+     *
+     * @param string|Stringable ...$items Items to add as `<li>` elements.
+     *
+     * @return static New instance with the appended list items.
      */
     public function items(string|Stringable ...$items): static
     {
@@ -63,19 +63,19 @@ final class Ol extends BaseBlock
     /**
      * Appends a `<li>` element to the ordered list.
      *
-     * @param string|Stringable $content Content for the `<li>` element.
-     * @param int|string|null $value Optional ordinal value for the list item, or `null` to omit the attribute.
-     *
-     * @return static New instance with the appended list item.
-     *
      * Usage example:
      * ```php
      * $list = \UIAwesome\Html\List\Ol::tag()
      *     ->li('Install dependencies')
      *     ->li('Run tests', 5);
      * ```
+     *
+     * @param string|Stringable $content Content for the `<li>` element.
+     * @param int|string|null $value Optional ordinal value for the list item, or `null` to omit the attribute.
+     *
+     * @return static New instance with the appended list item.
      */
-    public function li(string|Stringable $content, string|int|null $value = null): static
+    public function li(string|Stringable $content, int|string|null $value = null): static
     {
         $li = Li::tag()->content($content);
 

--- a/src/List/Ul.php
+++ b/src/List/Ul.php
@@ -9,24 +9,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{BlockInterface, Lists};
 
 /**
- * Represents the HTML `<ul>` element for unordered lists.
- *
- * Provides a concrete `<ul>` element implementation that returns `Lists::UL` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<ul>` element represents an unordered list of items, typically rendered as a bulleted list.
- *
- * Key features.
- * - Container element accepts `<li>` child elements.
- * - Provides helper methods `li()` and `items()` for constructing valid list markup.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<ul>` element for unordered lists.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\List\Ul;
- *
- * echo Ul::tag()
+ * echo \UIAwesome\Html\List\Ul::tag()
  *     ->class('my-list')
  *     ->items('First item', 'Second item', 'Third item')
  *     ->render();
@@ -41,17 +28,15 @@ use UIAwesome\Html\Interop\{BlockInterface, Lists};
 final class Ul extends BaseBlock
 {
     /**
-     * Appends multiple list items to the unordered list.
+     * Appends multiple `<li>` elements to the unordered list.
      *
-     * Creates a new instance with multiple `<li>` elements appended to the content.
-     *
-     * @param string|Stringable ...$items Variable number of items to add as list elements.
+     * @param string|Stringable ...$items Items to add as `<li>` elements.
      *
      * @return static New instance with the appended list items.
      *
      * Usage example:
      * ```php
-     * $list = Ul::tag()->items(
+     * $list = \UIAwesome\Html\List\Ul::tag()->items(
      *     'Apple',
      *     'Banana',
      *     'Cherry',
@@ -70,20 +55,16 @@ final class Ul extends BaseBlock
     }
 
     /**
-     * Appends a `<li>` element with the specified content to the unordered list.
+     * Appends a `<li>` element to the unordered list.
      *
-     * Creates a new instance with a `<li>` element appended to the content.
-     *
-     * @param string|Stringable $content Content to place inside the `<li>` element.
-     * @param int|string|null $value Optional ordinal value for the list item (only meaningful in ordered lists).
+     * @param string|Stringable $content Content for the `<li>` element.
+     * @param string|int|null $value Optional `value` attribute for the list item, or `null` to omit the attribute.
      *
      * @return static New instance with the appended list item.
      *
      * Usage example:
      * ```php
-     * $list = Ul::tag()
-     *     ->li('Item', 3);
-     * $list = Ul::tag()
+     * $list = \UIAwesome\Html\List\Ul::tag()
      *     ->li('First item')
      *     ->li('Second item');
      * ```

--- a/src/List/Ul.php
+++ b/src/List/Ul.php
@@ -58,7 +58,7 @@ final class Ul extends BaseBlock
      * Appends a `<li>` element to the unordered list.
      *
      * @param string|Stringable $content Content for the `<li>` element.
-     * @param string|int|null $value Optional `value` attribute for the list item, or `null` to omit the attribute.
+     * @param int|string|null $value Optional `value` attribute for the list item, or `null` to omit the attribute.
      *
      * @return static New instance with the appended list item.
      *

--- a/src/List/Ul.php
+++ b/src/List/Ul.php
@@ -30,10 +30,6 @@ final class Ul extends BaseBlock
     /**
      * Appends multiple `<li>` elements to the unordered list.
      *
-     * @param string|Stringable ...$items Items to add as `<li>` elements.
-     *
-     * @return static New instance with the appended list items.
-     *
      * Usage example:
      * ```php
      * $list = \UIAwesome\Html\List\Ul::tag()->items(
@@ -42,6 +38,10 @@ final class Ul extends BaseBlock
      *     'Cherry',
      * );
      * ```
+     *
+     * @param string|Stringable ...$items Items to add as `<li>` elements.
+     *
+     * @return static New instance with the appended list items.
      */
     public function items(string|Stringable ...$items): static
     {
@@ -57,17 +57,17 @@ final class Ul extends BaseBlock
     /**
      * Appends a `<li>` element to the unordered list.
      *
-     * @param string|Stringable $content Content for the `<li>` element.
-     * @param int|string|null $value Optional `value` attribute for the list item, or `null` to omit the attribute.
-     *
-     * @return static New instance with the appended list item.
-     *
      * Usage example:
      * ```php
      * $list = \UIAwesome\Html\List\Ul::tag()
      *     ->li('First item')
      *     ->li('Second item');
      * ```
+     *
+     * @param string|Stringable $content Content for the `<li>` element.
+     * @param int|string|null $value Optional `value` attribute for the list item, or `null` to omit the attribute.
+     *
+     * @return static New instance with the appended list item.
      */
     public function li(string|Stringable $content, string|int|null $value = null): static
     {

--- a/src/List/Ul.php
+++ b/src/List/Ul.php
@@ -69,7 +69,7 @@ final class Ul extends BaseBlock
      *
      * @return static New instance with the appended list item.
      */
-    public function li(string|Stringable $content, string|int|null $value = null): static
+    public function li(string|Stringable $content, int|string|null $value = null): static
     {
         $li = Li::tag()->content($content);
 

--- a/src/Metadata/Attribute/HasAsync.php
+++ b/src/Metadata/Attribute/HasAsync.php
@@ -5,14 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Metadata\Attribute;
 
 /**
- * Trait for managing the HTML `async` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `async` attribute on `<script>` elements.
- *
- * Key features.
- * - Handles the HTML `async` attribute for script execution.
- * - Immutable method for setting or overriding the `async` attribute.
- * - Supports bool for explicit async loading control.
+ * Provides an immutable API for the HTML `async` attribute.
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -25,12 +18,17 @@ namespace UIAwesome\Html\Metadata\Attribute;
 trait HasAsync
 {
     /**
-     * Sets the HTML `async` attribute for the element.
+     * Sets the `async` attribute.
      *
-     * Creates a new instance with the specified async value. When `true`, the script will be fetched in parallel to
-     * parsing and evaluated as soon as it is available.
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Metadata\Script::tag()
+     *     ->src('/assets/app.js')
+     *     ->async(true)
+     *     ->render();
+     * ```
      *
-     * @param bool $value Whether the script should be loaded asynchronously.
+     * @param bool $value Whether to execute the script asynchronously.
      *
      * @return static New instance with the updated `async` attribute.
      */

--- a/src/Metadata/Attribute/HasDefer.php
+++ b/src/Metadata/Attribute/HasDefer.php
@@ -5,14 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Metadata\Attribute;
 
 /**
- * Trait for managing the HTML `defer` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `defer` attribute on `<script>` elements.
- *
- * Key features.
- * - Handles the HTML `defer` attribute for script execution.
- * - Immutable method for setting or overriding the `defer` attribute.
- * - Supports bool for explicit deferred loading control.
+ * Provides an immutable API for the HTML `defer` attribute.
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -25,12 +18,17 @@ namespace UIAwesome\Html\Metadata\Attribute;
 trait HasDefer
 {
     /**
-     * Sets the HTML `defer` attribute for the element.
+     * Sets the `defer` attribute.
      *
-     * Creates a new instance with the specified defer value. When `true`, the script is meant to be executed after the
-     * document has been parsed, but before firing the DOMContentLoaded event.
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Metadata\Script::tag()
+     *     ->src('/assets/app.js')
+     *     ->defer(true)
+     *     ->render();
+     * ```
      *
-     * @param bool $value Whether the script should be deferred.
+     * @param bool $value Whether to defer script execution.
      *
      * @return static New instance with the updated `defer` attribute.
      */

--- a/src/Metadata/Attribute/HasNomodule.php
+++ b/src/Metadata/Attribute/HasNomodule.php
@@ -5,14 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Metadata\Attribute;
 
 /**
- * Trait for managing the HTML `nomodule` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `nomodule` attribute on `<script>` elements.
- *
- * Key features.
- * - Handles the HTML `nomodule` attribute for script execution.
- * - Immutable method for setting or overriding the `nomodule` attribute.
- * - Supports bool for explicit module fallback control.
+ * Provides an immutable API for the HTML `nomodule` attribute.
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -25,12 +18,17 @@ namespace UIAwesome\Html\Metadata\Attribute;
 trait HasNomodule
 {
     /**
-     * Sets the HTML `nomodule` attribute for the element.
+     * Sets the `nomodule` attribute.
      *
-     * Creates a new instance with the specified nomodule value. When `true`, the script should not be executed in
-     * browsers that support ES modules — in effect, this can be used to serve fallback scripts to older browsers.
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Metadata\Script::tag()
+     *     ->src('/assets/legacy.js')
+     *     ->nomodule(true)
+     *     ->render();
+     * ```
      *
-     * @param bool $value Whether the script should not be executed as a module.
+     * @param bool $value Whether to prevent execution in browsers that support modules.
      *
      * @return static New instance with the updated `nomodule` attribute.
      */

--- a/src/Metadata/Attribute/HasShadowRootClonable.php
+++ b/src/Metadata/Attribute/HasShadowRootClonable.php
@@ -5,14 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Metadata\Attribute;
 
 /**
- * Trait for managing the HTML `shadowrootclonable` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `shadowrootclonable` attribute on `<template>` elements.
- *
- * Key features.
- * - Handles the HTML `shadowrootclonable` attribute.
- * - Immutable method for setting or overriding the `shadowrootclonable` attribute.
- * - Supports bool for explicit shadow root cloning control.
+ * Provides an immutable API for the HTML `shadowrootclonable` attribute.
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -25,12 +18,16 @@ namespace UIAwesome\Html\Metadata\Attribute;
 trait HasShadowRootClonable
 {
     /**
-     * Sets the HTML `shadowrootclonable` attribute for the element.
+     * Sets the `shadowrootclonable` attribute.
      *
-     * Creates a new instance with the specified clonable value. When `true`, the shadow root is clonable when the
-     * `<template>` element is cloned.
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Metadata\Template::tag()
+     *     ->shadowRootClonable(true)
+     *     ->render();
+     * ```
      *
-     * @param bool $value Whether the shadow root should be clonable when the template is cloned.
+     * @param bool $value Whether to allow cloning the generated shadow root.
      *
      * @return static New instance with the updated `shadowrootclonable` attribute.
      */

--- a/src/Metadata/Attribute/HasShadowRootDelegatesFocus.php
+++ b/src/Metadata/Attribute/HasShadowRootDelegatesFocus.php
@@ -5,14 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Metadata\Attribute;
 
 /**
- * Trait for managing the HTML `shadowrootdelegatesfocus` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `shadowrootdelegatesfocus` attribute on `<template>` elements.
- *
- * Key features.
- * - Handles the HTML `shadowrootdelegatesfocus` attribute.
- * - Immutable method for setting or overriding the `shadowrootdelegatesfocus` attribute.
- * - Supports bool for explicit focus delegation control.
+ * Provides an immutable API for the HTML `shadowrootdelegatesfocus` attribute.
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -25,12 +18,16 @@ namespace UIAwesome\Html\Metadata\Attribute;
 trait HasShadowRootDelegatesFocus
 {
     /**
-     * Sets the HTML `shadowrootdelegatesfocus` attribute for the element.
+     * Sets the `shadowrootdelegatesfocus` attribute.
      *
-     * Creates a new instance with the specified delegates focus value. When `true`, the shadow root delegates focus to
-     * the first focusable element within the shadow tree when the host element is focused.
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Metadata\Template::tag()
+     *     ->shadowRootDelegatesFocus(true)
+     *     ->render();
+     * ```
      *
-     * @param bool $value Whether the shadow root should delegate focus to elements within the shadow tree.
+     * @param bool $value Whether to delegate focus into the generated shadow root.
      *
      * @return static New instance with the updated `shadowrootdelegatesfocus` attribute.
      */

--- a/src/Metadata/Attribute/HasShadowRootMode.php
+++ b/src/Metadata/Attribute/HasShadowRootMode.php
@@ -10,14 +10,7 @@ use UIAwesome\Html\Metadata\Values\ShadowRootMode;
 use UnitEnum;
 
 /**
- * Trait for managing the HTML `shadowrootmode` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `shadowrootmode` attribute on `<template>` elements.
- *
- * Key features.
- * - Handles the HTML `shadowrootmode` attribute.
- * - Immutable method for setting or overriding the `shadowrootmode` attribute.
- * - Supports string, UnitEnum, and `null` for flexible mode assignment.
+ * Provides an immutable API for the HTML `shadowrootmode` attribute.
  *
  * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -30,13 +23,16 @@ use UnitEnum;
 trait HasShadowRootMode
 {
     /**
-     * Sets the HTML `shadowrootmode` attribute for the element.
+     * Sets the `shadowrootmode` attribute.
      *
-     * Creates a new instance with the specified shadow root mode value. Defines the mode of the shadow root created
-     * from this `<template>` element. When set to `open`, the shadow root is accessible via JavaScript; when set to
-     * `closed`, the internal shadow root DOM is hidden from JavaScript. Can be `null` to unset the attribute.
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Metadata\Template::tag()
+     *     ->shadowRootMode(\UIAwesome\Html\Metadata\Values\ShadowRootMode::OPEN)
+     *     ->render();
+     * ```
      *
-     * @param string|UnitEnum|null $value Shadow root mode value to set for the element. Use `open` or `closed`.
+     * @param string|UnitEnum|null $value Shadow root mode (`open` or `closed`), or `null` to remove the attribute.
      *
      * @throws InvalidArgumentException if the provided value is not valid.
      *

--- a/src/Metadata/Attribute/HasShadowRootReferenceTarget.php
+++ b/src/Metadata/Attribute/HasShadowRootReferenceTarget.php
@@ -8,14 +8,7 @@ use Stringable;
 use UnitEnum;
 
 /**
- * Trait for managing the HTML `shadowrootreferencetarget` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `shadowrootreferencetarget` attribute on `<template>` elements.
- *
- * Key features.
- * - Handles the HTML `shadowrootreferencetarget` attribute.
- * - Immutable method for setting or overriding the `shadowrootreferencetarget` attribute.
- * - Supports string, Stringable, UnitEnum, and `null` for flexible reference target assignment.
+ * Provides an immutable API for the HTML `shadowrootreferencetarget` attribute.
  *
  * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -28,14 +21,16 @@ use UnitEnum;
 trait HasShadowRootReferenceTarget
 {
     /**
-     * Sets the HTML `shadowrootreferencetarget` attribute for the element.
+     * Sets the `shadowrootreferencetarget` attribute.
      *
-     * Creates a new instance with the specified reference target value. Specifies the ID of an element within the
-     * shadow root that should be used as the reference target for the shadow host element. Can be `null` to unset the
-     * attribute.
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Metadata\Template::tag()
+     *     ->shadowRootReferenceTarget('dialog-title')
+     *     ->render();
+     * ```
      *
-     * @param string|Stringable|UnitEnum|null $value Reference target ID to set for the element. Should be the ID of an
-     * element within the shadow root.
+     * @param string|Stringable|UnitEnum|null $value Reference target ID, or `null` to remove the attribute.
      *
      * @return static New instance with the updated `shadowrootreferencetarget` attribute.
      */

--- a/src/Metadata/Attribute/HasShadowRootSerializable.php
+++ b/src/Metadata/Attribute/HasShadowRootSerializable.php
@@ -5,14 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Metadata\Attribute;
 
 /**
- * Trait for managing the HTML `shadowrootserializable` attribute in tag rendering.
- *
- * Provides an immutable API for setting the `shadowrootserializable` attribute on `<template>` elements.
- *
- * Key features.
- * - Handles the HTML `shadowrootserializable` attribute.
- * - Immutable method for setting or overriding the `shadowrootserializable` attribute.
- * - Supports bool for explicit serialization control.
+ * Provides an immutable API for the HTML `shadowrootserializable` attribute.
  *
  * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
  * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
@@ -25,12 +18,16 @@ namespace UIAwesome\Html\Metadata\Attribute;
 trait HasShadowRootSerializable
 {
     /**
-     * Sets the HTML `shadowrootserializable` attribute for the element.
+     * Sets the `shadowrootserializable` attribute.
      *
-     * Creates a new instance with the specified serializable value. When `true`, the shadow root is serializable when
-     * the `<template>` element is serialized.
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Metadata\Template::tag()
+     *     ->shadowRootSerializable(true)
+     *     ->render();
+     * ```
      *
-     * @param bool $value Whether the shadow root should be serializable when the template is serialized.
+     * @param bool $value Whether to allow serializing the generated shadow root.
      *
      * @return static New instance with the updated `shadowrootserializable` attribute.
      */

--- a/src/Metadata/Base.php
+++ b/src/Metadata/Base.php
@@ -10,35 +10,13 @@ use UIAwesome\Html\Core\Element\BaseVoid;
 use UIAwesome\Html\Interop\{MetadataVoid, VoidInterface};
 
 /**
- * Represents the HTML `<base>` element for specifying the base URL and default target for relative URLs in a document.
- *
- * Provides a concrete `<base>` element implementation that returns `MetadataVoid::BASE` and inherits void-level
- * rendering and global attribute support from {@see BaseVoid}.
- *
- * The `<base>` element sets the base URL for all relative URLs and can specify a default target for hyperlinks and
- * forms. Only one `<base>` element is permitted per document, and it must appear inside the `<head>` element before any
- * other elements with URL attributes.
- *
- * Key features.
- * - Must be placed before other URL-dependent elements in `<head>`.
- * - Only one `<base>` element allowed per document.
- * - Supports base-specific attributes via helper methods (`href`, `target`).
- * - Void element renders without end tag.
+ * Renders the HTML `<base>` element for the document base URL and default navigation target.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Metadata\Base;
- *
- * echo Base::tag()
- *     ->href('https://example.com/')
- *     ->render();
- * echo Base::tag()
+ * echo \UIAwesome\Html\Metadata\Base::tag()
  *     ->href('https://example.com/')
  *     ->target('_blank')
- *     ->render();
- * echo Base::tag()
- *     ->href('/assets/')
- *     ->target(Target::BLANK)
  *     ->render();
  * ```
  *

--- a/src/Metadata/Link.php
+++ b/src/Metadata/Link.php
@@ -25,36 +25,13 @@ use UIAwesome\Html\Core\Element\BaseVoid;
 use UIAwesome\Html\Interop\{MetadataVoid, VoidInterface};
 
 /**
- * Represents the HTML `<link>` element for specifying relationships between the current document and external
- * resources.
- *
- * Provides a concrete `<link>` element implementation that returns `MetadataVoid::LINK` and inherits void-level
- * rendering and global attribute support from {@see BaseVoid}.
- *
- * The `<link>` element is a void element commonly used to link stylesheets, preloads, icons, and other resources.
- *
- * It supports a wide range of attributes to define resource type, relationship, and loading behavior.
- *
- * Key features.
- * - Integrates with global and metadata-specific attributes.
- * - Suitable for stylesheets, preloads, icons, and alternate resources.
- * - Supports link-specific attributes via helper methods (`rel`, `href`, `as`, `blocking`, `crossorigin`, etc.).
- * - Void element renders without an end tag.
+ * Renders the HTML `<link>` element for relationships to external resources.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Metadata\Link;
- *
- * echo Link::tag()
+ * echo \UIAwesome\Html\Metadata\Link::tag()
  *     ->rel('stylesheet')
  *     ->href('/css/site.css')
- *     ->render();
- * echo Link::tag()
- *     ->rel('preload')
- *     ->href('/fonts/font.woff2')
- *     ->as('font')
- *     ->type('font/woff2')
- *     ->crossorigin('anonymous')
  *     ->render();
  * ```
  *

--- a/src/Metadata/Meta.php
+++ b/src/Metadata/Meta.php
@@ -9,40 +9,13 @@ use UIAwesome\Html\Core\Element\BaseVoid;
 use UIAwesome\Html\Interop\{MetadataVoid, VoidInterface};
 
 /**
- * Represents the HTML `<meta>` element for document metadata.
- *
- * Provides a concrete `<meta>` element implementation that returns `MetadataVoid::META` and inherits void-level
- * rendering and global attribute support from {@see BaseVoid}.
- *
- * The `<meta>` element represents metadata that cannot be represented by other meta-related elements. The type of
- * metadata can be document-level metadata (with `name`), pragma directives (with `http-equiv`), charset declarations
- * (with `charset`), or user-defined metadata (with `itemprop`).
- *
- * Key features.
- * - Supports `charset` attribute for character encoding declarations.
- * - Supports `name` and `content` attributes for document-level metadata.
- * - Supports `http-equiv` and `content` attributes for pragma directives.
- * - Supports `media` attribute for theme-color metadata.
- * - Void element renders without end tag.
+ * Renders the HTML `<meta>` element for document metadata.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Metadata\Meta;
- *
- * echo Meta::tag()
- *     ->charset('utf-8')
- *     ->render();
- * echo Meta::tag()
+ * echo \UIAwesome\Html\Metadata\Meta::tag()
  *     ->name('viewport')
  *     ->content('width=device-width, initial-scale=1')
- *     ->render();
- * echo Meta::tag()
- *     ->name('description')
- *     ->content('A description of the page')
- *     ->render();
- * echo Meta::tag()
- *     ->httpEquiv('refresh')
- *     ->content('3;url=https://example.com')
  *     ->render();
  * ```
  *

--- a/src/Metadata/NoScript.php
+++ b/src/Metadata/NoScript.php
@@ -8,30 +8,12 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{BlockInterface, MetadataBlock};
 
 /**
- * Represents the HTML `<noscript>` element for fallback content when scripts are disabled.
- *
- * Provides a concrete `<noscript>` element implementation that returns `MetadataBlock::NOSCRIPT` and inherits
- * block-level rendering and global attribute support from {@see BaseBlock}.
- *
- * The `<noscript>` element defines a section of HTML to be inserted if a script type on the page is unsupported or if
- * scripting is currently turned off in the browser. When scripting is disabled, the element represents its children as
- * HTML content. When scripting is enabled, the element represents its children as text.
- *
- * Key features.
- * - Can be used in `<head>` (with link, style, meta) or in body (with transparent content).
- * - Container element accepts child content for fallback scenarios.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<noscript>` element for fallback content when scripting is unavailable.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Metadata\NoScript;
- *
- * echo NoScript::tag()
+ * echo \UIAwesome\Html\Metadata\NoScript::tag()
  *     ->content('Please enable JavaScript to use this application.')
- *     ->render();
- * echo NoScript::tag()
- *     ->html('<link rel="stylesheet" href="noscript.css">')
  *     ->render();
  * ```
  *

--- a/src/Metadata/Script.php
+++ b/src/Metadata/Script.php
@@ -18,33 +18,13 @@ use UIAwesome\Html\Interop\{BlockInterface, MetadataBlock};
 use UIAwesome\Html\Metadata\Attribute\{HasAsync, HasDefer, HasNomodule};
 
 /**
- * Represents the HTML `<script>` element for embedding executable code.
- *
- * Provides a concrete `<script>` element implementation that returns `MetadataBlock::SCRIPT` and inherits block-level
- * rendering and global attribute support from {@see BaseBlock}.
- *
- * The `<script>` element is used to embed executable code or data, typically JavaScript.
- *
- * Key features.
- * - Container element accepts child content for inline scripts.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
- * - Supports script-specific attributes via helper methods (`async`, `defer`, `nomodule`, `src`, `type`, etc.).
+ * Renders the HTML `<script>` element for executable code or data blocks.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Metadata\Script;
- *
- * echo Script::tag()
+ * echo \UIAwesome\Html\Metadata\Script::tag()
  *     ->src('https://example.com/app.js')
  *     ->async(true)
- *     ->render();
- * echo Script::tag()
- *     ->content('console.log("Hello World!");')
- *     ->render();
- * echo Script::tag()
- *     ->src('https://example.com/module.js')
- *     ->type('module')
  *     ->render();
  * ```
  *

--- a/src/Metadata/Style.php
+++ b/src/Metadata/Style.php
@@ -10,26 +10,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{BlockInterface, MetadataBlock};
 
 /**
- * Represents the HTML `<style>` element.
- *
- * Provides a concrete `<style>` element implementation that returns `MetadataBlock::STYLE` and inherits block-level
- * rendering and global attribute support from {@see BaseBlock}.
- *
- * The `<style>` element contains style information for a document.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `<style>` specific attributes via helper methods.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
- * - Supports style-specific attributes via helper methods (`media`, `nonce`, `type`, `blocking`).
+ * Renders the HTML `<style>` element for embedded CSS rules.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Metadata\Style;
- *
- * echo Style::tag()
- *     ->media('screen')
+ * echo \UIAwesome\Html\Metadata\Style::tag()
  *     ->content('body { color: red; }')
  *     ->render();
  * ```

--- a/src/Metadata/Template.php
+++ b/src/Metadata/Template.php
@@ -15,25 +15,11 @@ use UIAwesome\Html\Metadata\Attribute\{
 };
 
 /**
- * Represents the HTML `<template>` element for inert HTML fragments.
- *
- * Provides a concrete `<template>` element implementation that returns `MetadataBlock::TEMPLATE` and inherits
- * block-level rendering and global attribute support from {@see BaseBlock}.
- *
- * The `<template>` element is used to hold HTML fragments for later use.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
- * - Supports template-specific attributes via helper methods (`shadowroot*`).
+ * Renders the HTML `<template>` element for inert HTML fragments.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Metadata\Template;
- *
- * echo Template::tag()
- *     ->id('productrow')
+ * echo \UIAwesome\Html\Metadata\Template::tag()
  *     ->html('<tr><td></td></tr>')
  *     ->render();
  * ```

--- a/src/Metadata/Title.php
+++ b/src/Metadata/Title.php
@@ -8,23 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{BlockInterface, MetadataBlock};
 
 /**
- * Represents the HTML `<title>` element.
- *
- * Provides a concrete `<title>` element implementation that returns `MetadataBlock::TITLE` and inherits block-level
- * rendering and global attribute support from {@see BaseBlock}.
- *
- * The `<title>` element defines the document's title shown in the browser's title bar or tab.
- *
- * Key features.
- * - Element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<title>` element for the document title.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Metadata\Title;
- *
- * echo Title::tag()
+ * echo \UIAwesome\Html\Metadata\Title::tag()
  *     ->content('My page')
  *     ->render();
  * ```

--- a/src/Metadata/Values/ShadowRootMode.php
+++ b/src/Metadata/Values/ShadowRootMode.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Metadata\Values;
 
 /**
- * Represents values for the HTML `shadowrootmode` attribute.
+ * Represents tokens for the HTML `shadowrootmode` attribute.
  *
- * Defines the supported `shadowrootmode` tokens as enum cases.
- *
- * Key features.
- * - Enum values map to `'open'` and `'closed'` tokens.
+ * Usage example:
+ * ```php
+ * $mode = \UIAwesome\Html\Metadata\Values\ShadowRootMode::OPEN;
+ * echo $mode->value;
+ * ```
  *
  * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template#shadowrootmode
  *
@@ -20,12 +21,12 @@ namespace UIAwesome\Html\Metadata\Values;
 enum ShadowRootMode: string
 {
     /**
-     * Hides the internal shadow root DOM from JavaScript (`closed`).
+     * Represents the `closed` token.
      */
     case CLOSED = 'closed';
 
     /**
-     * Exposes the internal shadow root DOM for JavaScript (`open`).
+     * Represents the `open` token.
      */
     case OPEN = 'open';
 }

--- a/src/Palpable/A.php
+++ b/src/Palpable/A.php
@@ -4,37 +4,25 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Palpable;
 
+use UIAwesome\Html\Attribute\{
+    HasDownload,
+    HasHreflang,
+    HasPing,
+    HasReferrerpolicy,
+    HasRel,
+    HasTarget,
+    HasType,
+};
 use UIAwesome\Html\Attribute\Element\HasHref;
-use UIAwesome\Html\Attribute\HasDownload;
-use UIAwesome\Html\Attribute\HasHreflang;
-use UIAwesome\Html\Attribute\HasPing;
-use UIAwesome\Html\Attribute\HasReferrerpolicy;
-use UIAwesome\Html\Attribute\HasRel;
-use UIAwesome\Html\Attribute\HasTarget;
-use UIAwesome\Html\Attribute\HasType;
 use UIAwesome\Html\Core\Element\BaseInline;
 use UIAwesome\Html\Interop\{Inline, InlineInterface};
 
 /**
- * Represents the HTML `<a>` element for creating hyperlinks.
- *
- * Provides a concrete `<a>` element implementation that returns `Inline::A` and inherits inline-level rendering and
- * global attribute support from {@see BaseInline}.
- *
- * The `<a>` element (or anchor element), with its `href` attribute, creates a hyperlink to web pages, files, email
- * addresses, locations in the same page, or anything else a URL can address.
- *
- * Key features.
- * - Inline element accepts child content.
- * - Supports anchor-specific attributes: `download`, `href`, `hreflang`, `ping`, `referrerpolicy`, `rel`, `target`,
- *   `type`.
- * - Supports global HTML attributes via {@see BaseInline}.
+ * Renders the HTML `<a>` element for hyperlinks.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Palpable\A;
- *
- * echo A::tag()
+ * echo \UIAwesome\Html\Palpable\A::tag()
  *     ->href('https://example.com')
  *     ->content('Visit Example');
  * ```

--- a/src/Phrasing/I.php
+++ b/src/Phrasing/I.php
@@ -8,24 +8,11 @@ use UIAwesome\Html\Core\Element\BaseInline;
 use UIAwesome\Html\Interop\{Inline, InlineInterface};
 
 /**
- * Represents the HTML `<i>` element for idiomatic text.
- *
- * Provides a concrete `<i>` element implementation that returns `Inline::I` and inherits inline-level rendering and
- * global attribute support from {@see BaseInline}.
- *
- * The `<i>` element represents a range of text that is set off from the normal text for some reason, such as idiomatic
- * text, technical terms, taxonomical designations, among others. Historically, these have been presented using
- * italicized type, which is the original source of the `<i>` naming of this element.
- *
- * Key features.
- * - Inline element accepts child content.
- * - Supports global HTML attributes via {@see BaseInline}.
+ * Renders the HTML `<i>` element for alternate voice or idiomatic text.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Flow\I;
- *
- * echo I::tag()
+ * echo \UIAwesome\Html\Phrasing\I::tag()
  *     ->class('technical-term')
  *     ->content('Veni, vidi, vici')
  *     ->render();

--- a/src/Phrasing/Span.php
+++ b/src/Phrasing/Span.php
@@ -8,23 +8,11 @@ use UIAwesome\Html\Core\Element\BaseInline;
 use UIAwesome\Html\Interop\{Inline, InlineInterface};
 
 /**
- * Represents the HTML `<span>` element for grouping inline content.
- *
- * Provides a concrete `<span>` element implementation that returns `Inline::SPAN` and inherits inline-level rendering
- * and global attribute support from {@see BaseInline}.
- *
- * The `<span>` element is a generic inline container for phrasing content, which does not inherently represent
- * anything. It should be used only when no other semantic element is appropriate.
- *
- * Key features.
- * - Inline element accepts child content.
- * - Supports global HTML attributes via {@see BaseInline}.
+ * Renders the HTML `<span>` element for generic inline content.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Flow\Span;
- *
- * echo Span::tag()
+ * echo \UIAwesome\Html\Phrasing\Span::tag()
  *     ->class('highlight')
  *     ->content('Highlighted text')
  *     ->render();

--- a/src/Root/Body.php
+++ b/src/Root/Body.php
@@ -8,23 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{BlockInterface, Root};
 
 /**
- * Represents the HTML `<body>` (body) element for document body content.
- *
- * Provides a concrete `<body>` element implementation that returns `Root::BODY` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<body>` element represents the contents of an HTML document.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<body>` element for document content.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Root\Body;
- *
- * echo Body::tag()
+ * echo \UIAwesome\Html\Root\Body::tag()
  *     ->class('app')
  *     ->content('value')
  *     ->render();

--- a/src/Root/Footer.php
+++ b/src/Root/Footer.php
@@ -8,25 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<footer>` element for section footer content.
- *
- * Provides a concrete `<footer>` element implementation that returns `Block::FOOTER` and inherits block-level rendering
- * and global attribute support from {@see BaseBlock}.
- *
- * The `<footer>` element represents a footer for its nearest ancestor sectioning content or sectioning root element.
- * A `<footer>` typically contains information about the author of the section, copyright data or links to related
- * documents.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<footer>` element for section or page footer content.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Flow\Footer;
- *
- * echo Footer::tag()
+ * echo \UIAwesome\Html\Root\Footer::tag()
  *     ->class('page-footer')
  *     ->content('© 2026 Company Name')
  *     ->render();

--- a/src/Root/Head.php
+++ b/src/Root/Head.php
@@ -8,23 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{BlockInterface, Root};
 
 /**
- * Represents the HTML `<head>` element for document metadata.
- *
- * Provides a concrete `<head>` element implementation that returns `Root::HEAD` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<head>` element contains machine-readable information (metadata) about the document.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<head>` element for document metadata.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Root\Head;
- *
- * echo Head::tag()
+ * echo \UIAwesome\Html\Root\Head::tag()
  *     ->content('value')
  *     ->render();
  * ```

--- a/src/Root/Header.php
+++ b/src/Root/Header.php
@@ -8,25 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<header>` element for section header content.
- *
- * Provides a concrete `<header>` element implementation that returns `Block::HEADER` and inherits block-level rendering
- * and global attribute support from {@see BaseBlock}.
- *
- * The `<header>` element represents introductory content, typically a group of introductory or navigational aids.
- *
- * It may contain some heading elements but also a logo, a search form, an author name, and other elements.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<header>` element for section or page header content.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Root\Header;
- *
- * echo Header::tag()
+ * echo \UIAwesome\Html\Root\Header::tag()
  *     ->class('page-header')
  *     ->content('Welcome to the Site')
  *     ->render();

--- a/src/Root/Html.php
+++ b/src/Root/Html.php
@@ -8,23 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{BlockInterface, Root};
 
 /**
- * Represents the HTML `<html>` element (document root).
- *
- * Provides a concrete `<html>` element implementation that returns `Root::HTML` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<html>` element is the root element of an HTML document.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<html>` element as the document root.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Root\Html;
- *
- * echo Html::tag()
+ * echo \UIAwesome\Html\Root\Html::tag()
  *     ->lang('en')
  *     ->content('value')
  *     ->render();

--- a/src/Sectioning/Article.php
+++ b/src/Sectioning/Article.php
@@ -8,26 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<article>` element for self-contained composition content.
- *
- * Provides a concrete `<article>` element implementation that returns `Block::ARTICLE` and inherits block-level
- * rendering and global attribute support from {@see BaseBlock}.
- *
- * The `<article>` element represents a self-contained composition in a document, page, application, or site, which is
- * intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a
- * magazine or newspaper article, or a blog entry, a product card, a user-submitted comment, an interactive widget or
- * gadget, or any other independent item of content.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<article>` element for self-contained content.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Sectioning\Article;
- *
- * echo Article::tag()
+ * echo \UIAwesome\Html\Sectioning\Article::tag()
  *     ->class('blog-post')
  *     ->content('Article content here')
  *     ->render();

--- a/src/Sectioning/Aside.php
+++ b/src/Sectioning/Aside.php
@@ -8,24 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<aside>` element for tangentially related content.
+ * Renders the HTML `<aside>` element for tangentially related content.
  *
- * Provides a concrete `<aside>` element implementation that returns `Block::ASIDE` and inherits block-level rendering
- * and global attribute support from {@see BaseBlock}.
- *
- * The `<aside>` element represents a portion of a document whose content is only indirectly related to the document's
- * main content. Asides are frequently presented as sidebars or call-out boxes.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
- *
- * Usage example.
+ * Usage example:
  * ```php
- * use UIAwesome\Html\Sectioning\Aside;
- *
- * echo Aside::tag()
+ * echo \UIAwesome\Html\Sectioning\Aside::tag()
  *     ->class('sidebar')
  *     ->content('Sidebar content here')
  *     ->render();

--- a/src/Sectioning/Nav.php
+++ b/src/Sectioning/Nav.php
@@ -8,25 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<nav>` element for navigation sections.
+ * Renders the HTML `<nav>` element for navigation sections.
  *
- * Provides a concrete `<nav>` element implementation that returns `Block::NAV` and inherits block-level rendering and
- * global attribute support from {@see BaseBlock}.
- *
- * The `<nav>` element represents a section of a page whose purpose is to provide navigation links, either within the
- * current document or to other documents. Common examples of navigation sections are menus, tables of contents, and
- * indexes.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
- *
- * Usage example.
+ * Usage example:
  * ```php
- * use UIAwesome\Html\Sectioning\Nav;
- *
- * echo Nav::tag()
+ * echo \UIAwesome\Html\Sectioning\Nav::tag()
  *     ->class('main-menu')
  *     ->content('Navigation links here')
  *     ->render();

--- a/src/Sectioning/Section.php
+++ b/src/Sectioning/Section.php
@@ -8,25 +8,11 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\{Block, BlockInterface};
 
 /**
- * Represents the HTML `<section>` element for generic standalone sections.
- *
- * Provides a concrete `<section>` element implementation that returns `Block::SECTION` and inherits block-level
- * rendering and global attribute support from {@see BaseBlock}.
- *
- * The `<section>` element represents a generic standalone section of a document, which doesn't have a more specific
- * semantic element to represent it. Sections should always have a heading, with very few exceptions. Examples include:
- * chapters, tabbed pages, content areas with headings, or distinct sections of a document.
- *
- * Key features.
- * - Container element accepts child content.
- * - Supports `begin()`/`end()` rendering via {@see BaseBlock}.
- * - Supports global HTML attributes via {@see BaseBlock}.
+ * Renders the HTML `<section>` element for standalone document sections.
  *
  * Usage example:
  * ```php
- * use UIAwesome\Html\Sectioning\Section;
- *
- * echo Section::tag()
+ * echo \UIAwesome\Html\Sectioning\Section::tag()
  *     ->class('content-section')
  *     ->content('Section content here')
  *     ->render();


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
