### PR TITLE
feat(form); Add `InputSubmit` class for HTML `<input type="submit">` element with attributes and rendering capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Enh #22: Add `InputTime` class for HTML `<input type="time">` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #23: Add `InputText` class for HTML `<input type="text">` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #24: Add `InputTel` class for HTML `<input type="tel">` element with attributes and rendering capabilities (@terabytesoftw)
+- Enh #25: Add `InputSubmit` class for HTML `<input type="submit">` element with attributes and rendering capabilities (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Form/Attribute/HasFormaction.php
+++ b/src/Form/Attribute/HasFormaction.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+use Stringable;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the HTML `formaction` attribute.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/formaction
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasFormaction
+{
+    /**
+     * Sets the `formaction` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\InputSubmit::tag()->formaction('/submit')->render();
+     * ```
+     *
+     * @param string|Stringable|UnitEnum|null $value The URL for form submission.
+     *
+     * @return static New instance with the updated `formaction` attribute.
+     */
+    public function formaction(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute('formaction', $value);
+    }
+}

--- a/src/Form/Attribute/HasFormenctype.php
+++ b/src/Form/Attribute/HasFormenctype.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+use Stringable;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the HTML `formenctype` attribute.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/formenctype
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasFormenctype
+{
+    /**
+     * Sets the `formenctype` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\InputSubmit::tag()->formenctype('multipart/form-data')->render();
+     * ```
+     *
+     * @param string|Stringable|UnitEnum|null $value The encoding type for form submission.
+     *
+     * @return static New instance with the updated `formenctype` attribute.
+     */
+    public function formenctype(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute('formenctype', $value);
+    }
+}

--- a/src/Form/Attribute/HasFormmethod.php
+++ b/src/Form/Attribute/HasFormmethod.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+use Stringable;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the HTML `formmethod` attribute.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/formmethod
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasFormmethod
+{
+    /**
+     * Sets the `formmethod` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\InputSubmit::tag()->formmethod('post')->render();
+     * ```
+     *
+     * @param string|Stringable|UnitEnum|null $value The HTTP method for form submission.
+     *
+     * @return static New instance with the updated `formmethod` attribute.
+     */
+    public function formmethod(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute('formmethod', $value);
+    }
+}

--- a/src/Form/Attribute/HasFormnovalidate.php
+++ b/src/Form/Attribute/HasFormnovalidate.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+/**
+ * Provides an immutable API for the HTML `formnovalidate` attribute.
+ *
+ * @method static addAttribute(string|\UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/formnovalidate
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasFormnovalidate
+{
+    /**
+     * Sets the `formnovalidate` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\InputSubmit::tag()->formnovalidate(true)->render();
+     * ```
+     *
+     * @param bool|null $value Whether to bypass form validation.
+     *
+     * @return static New instance with the updated `formnovalidate` attribute.
+     */
+    public function formnovalidate(bool|null $value): static
+    {
+        return $this->addAttribute('formnovalidate', $value);
+    }
+}

--- a/src/Form/Attribute/HasFormtarget.php
+++ b/src/Form/Attribute/HasFormtarget.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+use Stringable;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the HTML `formtarget` attribute.
+ *
+ * @method static addAttribute(string|UnitEnum $key, mixed $value) Adds an attribute and returns a new instance.
+ * {@see \UIAwesome\Html\Mixin\HasAttributes} for managing the underlying attributes array.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/formtarget
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasFormtarget
+{
+    /**
+     * Sets the `formtarget` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\InputSubmit::tag()->formtarget('_blank')->render();
+     * ```
+     *
+     * @param string|Stringable|UnitEnum|null $value The browsing context for form submission response.
+     *
+     * @return static New instance with the updated `formtarget` attribute.
+     */
+    public function formtarget(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->addAttribute('formtarget', $value);
+    }
+}

--- a/src/Form/InputSubmit.php
+++ b/src/Form/InputSubmit.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form;
+
+use UIAwesome\Html\Attribute\Form\HasForm;
+use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
+use UIAwesome\Html\Attribute\HasValue;
+use UIAwesome\Html\Attribute\Values\Type;
+use UIAwesome\Html\Core\Element\BaseInput;
+use UIAwesome\Html\Form\Attribute\{
+    HasFormaction,
+    HasFormenctype,
+    HasFormmethod,
+    HasFormnovalidate,
+    HasFormtarget
+};
+use UIAwesome\Html\Interop\{VoidInterface, Voids};
+
+/**
+ * Represents the HTML `<input type="submit">` element.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Form\InputSubmit::tag()
+ *     ->value('Save')
+ *     ->class('btn btn-primary')
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/submit
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class InputSubmit extends BaseInput
+{
+    use CanBeAutofocus;
+    use HasForm;
+    use HasFormaction;
+    use HasFormenctype;
+    use HasFormmethod;
+    use HasFormnovalidate;
+    use HasFormtarget;
+    use HasTabindex;
+    use HasValue;
+
+    /**
+     * Returns the tag enumeration for the `<input>` element.
+     *
+     * @return VoidInterface Tag enumeration instance for `<input>`.
+     */
+    protected function getTag(): VoidInterface
+    {
+        return Voids::INPUT;
+    }
+
+    /**
+     * Returns the default configuration for the input element.
+     *
+     * @return array Default configuration array with method calls as keys.
+     *
+     * @phpstan-return array<string, mixed>
+     */
+    protected function loadDefault(): array
+    {
+        return parent::loadDefault() + ['type' => [Type::SUBMIT]];
+    }
+
+    /**
+     * Renders the `<input>` element with its attributes.
+     *
+     * @return string Rendered HTML for the `<input>` element.
+     */
+    protected function run(): string
+    {
+        return $this->buildElement();
+    }
+}

--- a/tests/Form/InputSubmitTest.php
+++ b/tests/Form/InputSubmitTest.php
@@ -1,0 +1,542 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Form;
+
+use PHPForge\Support\LineEndingNormalizer;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{Aria, Data, Direction, GlobalAttribute, Language, Role, Translate};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Form\InputSubmit;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see InputSubmit} submit input behavior.
+ *
+ * Test coverage.
+ * - Applies input-submit-specific attributes (`autofocus`, `form`, `formaction`, `formenctype`, `formmethod`,
+ *   `formnovalidate`, `formtarget`, `name`, `tabindex`, `value`) and renders expected output.
+ * - Applies global and custom attributes, including `aria-*`, `data-*`, and enum-backed values.
+ * - Renders attributes and string casting for a void element.
+ * - Resolves default and theme providers, including global defaults and user overrides.
+ *
+ * {@see InputSubmit} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('html')]
+#[Group('form')]
+final class InputSubmitTest extends TestCase
+{
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'default',
+            InputSubmit::tag()->getAttribute('data-test', 'default'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" accesskey="k">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->accesskey('k')->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" aria-label="Submit form">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->addAriaAttribute('label', 'Submit form')->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" aria-hidden="true">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->addAriaAttribute(Aria::HIDDEN, true)->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" data-test="value">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->addAttribute('data-test', 'value')->render(),
+            "Failed asserting that element renders correctly with 'addAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" title="Submit action">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->addAttribute(GlobalAttribute::TITLE, 'Submit action')->render(),
+            "Failed asserting that element renders correctly with 'addAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" data-submit="value">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->addDataAttribute('submit', 'value')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" data-value="test">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->addDataAttribute(Data::VALUE, 'test')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" aria-controls="submit-region" aria-label="Submit now">
+            HTML,
+            InputSubmit::tag()
+                ->id('inputsubmit-')
+                ->ariaAttributes([
+                    'controls' => 'submit-region',
+                    'label' => 'Submit now',
+                ])
+                ->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="submit-input" id="inputsubmit-" type="submit">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->attributes(['class' => 'submit-input'])->render(),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" autofocus>
+            HTML,
+            InputSubmit::tag()->autofocus(true)->id('inputsubmit-')->render(),
+            "Failed asserting that element renders correctly with 'autofocus' attribute.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="submit-input" id="inputsubmit-" type="submit">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->class('submit-input')->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" data-submit="value">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->dataAttributes(['submit' => 'value'])->render(),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputsubmit-" type="submit">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->attributes(['class' => 'default-class'])->render(),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputsubmit-" type="submit" title="default-title">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->addDefaultProvider(DefaultProvider::class)->render(),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultValues(): void
+    {
+        $output = InputSubmit::tag()->render();
+
+        self::assertStringContainsString('type="submit"', $output);
+        self::assertStringContainsString('<input', $output);
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" dir="ltr">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->dir('ltr')->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" dir="ltr">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->dir(Direction::LTR)->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithDisabled(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" disabled>
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->disabled(true)->render(),
+            "Failed asserting that element renders correctly with 'disabled' attribute.",
+        );
+    }
+
+    public function testRenderWithForm(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" form="form-id">
+            HTML,
+            InputSubmit::tag()->form('form-id')->id('inputsubmit-')->render(),
+            "Failed asserting that element renders correctly with 'form' attribute.",
+        );
+    }
+
+    public function testRenderWithFormaction(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" formaction="/submit-handler">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->formaction('/submit-handler')->render(),
+            "Failed asserting that element renders correctly with 'formaction' attribute.",
+        );
+    }
+
+    public function testRenderWithFormenctype(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" formenctype="multipart/form-data">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->formenctype('multipart/form-data')->render(),
+            "Failed asserting that element renders correctly with 'formenctype' attribute.",
+        );
+    }
+
+    public function testRenderWithFormmethod(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" formmethod="post">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->formmethod('post')->render(),
+            "Failed asserting that element renders correctly with 'formmethod' attribute.",
+        );
+    }
+
+    public function testRenderWithFormnovalidate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" formnovalidate>
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->formnovalidate(true)->render(),
+            "Failed asserting that element renders correctly with 'formnovalidate' attribute.",
+        );
+    }
+
+    public function testRenderWithFormtarget(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" formtarget="_blank">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->formtarget('_blank')->render(),
+            "Failed asserting that element renders correctly with 'formtarget' attribute.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(InputSubmit::class, ['class' => 'default-class']);
+
+        self::assertStringContainsString(
+            'class="default-class"',
+            InputSubmit::tag()->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(InputSubmit::class, []);
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" hidden>
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->hidden(true)->render(),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="submit-input" type="submit">
+            HTML,
+            InputSubmit::tag()->id('submit-input')->render(),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" lang="en">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->lang('en')->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" lang="en">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->lang(Language::ENGLISH)->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithName(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" name="save" type="submit">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->name('save')->render(),
+            "Failed asserting that element renders correctly with 'name' attribute.",
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit">
+            HTML,
+            InputSubmit::tag()
+                ->id('inputsubmit-')
+                ->addAriaAttribute('label', 'Close')
+                ->removeAriaAttribute('label')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit">
+            HTML,
+            InputSubmit::tag()
+                ->id('inputsubmit-')
+                ->addAttribute('data-test', 'value')
+                ->removeAttribute('data-test')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit">
+            HTML,
+            InputSubmit::tag()
+                ->id('inputsubmit-')
+                ->addDataAttribute('value', 'test')
+                ->removeDataAttribute('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" role="button">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->role('button')->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" role="button">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->role(Role::BUTTON)->render(),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" style='width: 200px;'>
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->style('width: 200px;')->render(),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" tabindex="1">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->tabIndex(1)->render(),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="text-muted" id="inputsubmit-" type="submit">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->addThemeProvider('muted', DefaultThemeProvider::class)->render(),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" title="Submit form">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->title('Submit form')->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertStringContainsString(
+            'type="submit"',
+            LineEndingNormalizer::normalize((string) InputSubmit::tag()),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" translate="no">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->translate(false)->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" translate="no">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->translate(Translate::NO)->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(InputSubmit::class, ['class' => 'from-global', 'id' => 'id-global']);
+
+        $output = InputSubmit::tag(['id' => 'id-user'])->render();
+
+        self::assertStringContainsString('class="from-global"', $output);
+        self::assertStringContainsString('id="id-user"', $output);
+
+        SimpleFactory::setDefaults(InputSubmit::class, []);
+    }
+
+    public function testRenderWithValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit" value="Save">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->value('Save')->render(),
+            "Failed asserting that element renders correctly with 'value' attribute.",
+        );
+    }
+}

--- a/tests/Form/InputSubmitTest.php
+++ b/tests/Form/InputSubmitTest.php
@@ -184,7 +184,7 @@ final class InputSubmitTest extends TestCase
             <<<HTML
             <input class="default-class" id="inputsubmit-" type="submit">
             HTML,
-            InputSubmit::tag()->id('inputsubmit-')->attributes(['class' => 'default-class'])->render(),
+            InputSubmit::tag(['class' => 'default-class'])->id('inputsubmit-')->render(),
             'Failed asserting that default configuration values are applied correctly.',
         );
     }

--- a/tests/Form/InputSubmitTest.php
+++ b/tests/Form/InputSubmitTest.php
@@ -296,6 +296,28 @@ final class InputSubmitTest extends TestCase
         );
     }
 
+    public function testRenderWithFormnovalidateValueFalse(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->formnovalidate(false)->render(),
+            "Failed asserting that element renders correctly with 'formnovalidate' set to false.",
+        );
+    }
+
+    public function testRenderWithFormnovalidateValueNull(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputsubmit-" type="submit">
+            HTML,
+            InputSubmit::tag()->id('inputsubmit-')->formnovalidate(null)->render(),
+            "Failed asserting that element renders correctly with 'formnovalidate' set to null.",
+        );
+    }
+
     public function testRenderWithFormtarget(): void
     {
         self::assertSame(

--- a/tests/Form/InputTelTest.php
+++ b/tests/Form/InputTelTest.php
@@ -208,7 +208,7 @@ final class InputTelTest extends TestCase
             <<<HTML
             <input class="default-class" id="inputtel-" type="tel">
             HTML,
-            InputTel::tag()->id('inputtel-')->attributes(['class' => 'default-class'])->render(),
+            InputTel::tag(['class' => 'default-class'])->id('inputtel-')->render(),
             'Failed asserting that default configuration values are applied correctly.',
         );
     }

--- a/tests/Form/InputTextTest.php
+++ b/tests/Form/InputTextTest.php
@@ -207,7 +207,7 @@ final class InputTextTest extends TestCase
             <<<HTML
             <input class="default-class" id="inputtext-" type="text">
             HTML,
-            InputText::tag()->id('inputtext-')->attributes(['class' => 'default-class'])->render(),
+            InputText::tag(['class' => 'default-class'])->id('inputtext-')->render(),
             'Failed asserting that default configuration values are applied correctly.',
         );
     }

--- a/tests/Form/InputTimeTest.php
+++ b/tests/Form/InputTimeTest.php
@@ -206,7 +206,7 @@ final class InputTimeTest extends TestCase
             <<<HTML
             <input class="default-class" id="inputtime-" type="time">
             HTML,
-            InputTime::tag()->id('inputtime-')->attributes(['class' => 'default-class'])->render(),
+            InputTime::tag(['class' => 'default-class'])->id('inputtime-')->render(),
             'Failed asserting that default configuration values are applied correctly.',
         );
     }

--- a/tests/Form/InputUrlTest.php
+++ b/tests/Form/InputUrlTest.php
@@ -208,7 +208,7 @@ final class InputUrlTest extends TestCase
             <<<HTML
             <input class="default-class" id="inputurl-" type="url">
             HTML,
-            InputUrl::tag()->id('inputurl-')->attributes(['class' => 'default-class'])->render(),
+            InputUrl::tag(['class' => 'default-class'])->id('inputurl-')->render(),
             'Failed asserting that default configuration values are applied correctly.',
         );
     }

--- a/tests/Form/InputWeekTest.php
+++ b/tests/Form/InputWeekTest.php
@@ -206,7 +206,7 @@ final class InputWeekTest extends TestCase
             <<<HTML
             <input class="default-class" id="inputweek-" type="week">
             HTML,
-            InputWeek::tag()->id('inputweek-')->attributes(['class' => 'default-class'])->render(),
+            InputWeek::tag(['class' => 'default-class'])->id('inputweek-')->render(),
             'Failed asserting that default configuration values are applied correctly.',
         );
     }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
