### PR TITLE
Add `Label` class for HTML `<label>` element with attributes and rendering capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Enh #28: Add `InputRange` class for HTML `<input type="range">` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #29: Add `InputPassword` class for HTML `<input type="password">` element with attributes and rendering capabilities (@terabytesoftw)
 - Bug #30: Update parameter descriptions to clarify usage for form attributes and input elements (@terabytesoftw)
+- Enh #31: Add `Label` class for HTML `<label>` element with attributes and rendering capabilities (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Phrasing/Label.php
+++ b/src/Phrasing/Label.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Phrasing;
+
+use UIAwesome\Html\Core\Element\BaseInline;
+use UIAwesome\Html\Interop\{Inline, InlineInterface};
+
+/**
+ * Renders the HTML `<label>` element.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Phrasing\Label::tag()
+ *     ->content('Email Address')
+ *     ->for('email')
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
+ * {@see BaseInline} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class Label extends BaseInline
+{
+    /**
+     * Sets the `for` attribute.
+     *
+     * Usage example:
+     * ```php
+     * $label = Label::tag()->for('username');
+     * ```
+     *
+     * @param string|null $value ID of a labelable form-related element in the same document as the label element, or
+     * `null` to remove the attribute.
+     *
+     * @return static New instance with the updated `for` attribute.
+     */
+    public function for(string|null $value = null): static
+    {
+        return $this->addAttribute('for', $value);
+    }
+
+    /**
+     * Returns the tag enumeration for the `<label>` element.
+     *
+     * @return InlineInterface Tag enumeration instance for `<label>`.
+     *
+     * {@see Inline} for valid inline-level tags.
+     */
+    protected function getTag(): InlineInterface
+    {
+        return Inline::LABEL;
+    }
+
+    /**
+     * Renders the `<label>` element with its content and attributes.
+     *
+     * @return string Rendered HTML for the `<label>` element.
+     */
+    protected function run(): string
+    {
+        return $this->buildElement($this->getContent());
+    }
+}

--- a/tests/Phrasing/LabelTest.php
+++ b/tests/Phrasing/LabelTest.php
@@ -1,0 +1,560 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Phrasing;
+
+use PHPForge\Support\LineEndingNormalizer;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{
+    Aria,
+    Data,
+    Direction,
+    GlobalAttribute,
+    Language,
+    Role,
+    Translate,
+};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Phrasing\Label;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see Label} inline phrasing behavior.
+ *
+ * Test coverage.
+ * - Applies global and custom attributes, including `aria-*`, `data-*`, and enum-backed values.
+ * - Ensures attribute accessors return assigned values and fallback defaults.
+ * - Renders content, raw HTML, and string casting with expected encoding behavior.
+ * - Resolves default and theme providers, including global defaults and user overrides.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('html')]
+#[Group('phrasing')]
+final class LabelTest extends TestCase
+{
+    public function testContentEncodesValues(): void
+    {
+        $label = Label::tag()->content('<value>');
+
+        self::assertSame(
+            '&lt;value&gt;',
+            $label->getContent(),
+            "Failed asserting that 'content()' method encodes values correctly.",
+        );
+    }
+
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'default',
+            Label::tag()->getAttribute('data-test', 'default'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testGetAttributesReturnsAssignedAttributes(): void
+    {
+        self::assertSame(
+            ['data-test' => 'value'],
+            Label::tag()->addAttribute('data-test', 'value')->getAttributes(),
+            "Failed asserting that 'getAttributes()' returns the assigned attributes.",
+        );
+    }
+
+    public function testHtmlDoesNotEncodeValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label><value></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->html('<value>')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'html()' method.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label accesskey="k"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->accesskey('k')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label aria-label="Label content"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->addAriaAttribute('label', 'Label content')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label aria-hidden="true"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->addAriaAttribute(Aria::HIDDEN, true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label data-test="value"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->addAttribute('data-test', 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label title="Label content"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->addAttribute(GlobalAttribute::TITLE, 'Label content')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label data-value="value"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->addDataAttribute('value', 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label data-value="value"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->addDataAttribute(Data::VALUE, 'value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label aria-controls="modal-1" aria-hidden="false" aria-label="Close"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()
+                    ->ariaAttributes(
+                        [
+                            'controls' => static fn(): string => 'modal-1',
+                            'hidden' => false,
+                            'label' => 'Close',
+                        ],
+                    )
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label class="value"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->attributes(['class' => 'value'])->render(),
+            ),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label class="value"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->class('value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithContent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label>value</label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->content('value')->render(),
+            ),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label data-value="value"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->dataAttributes(['value' => 'value'])->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label class="default-class"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag(['class' => 'default-class'])->render(),
+            ),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label class="default-class" title="default-title"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->addDefaultProvider(DefaultProvider::class)->render(),
+            ),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->render(),
+            ),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label dir="ltr"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->dir('ltr')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label dir="ltr"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->dir(Direction::LTR)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'dir' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithFor(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label for="email"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->for('email')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'for' attribute.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(Label::class, ['class' => 'default-class']);
+
+        self::assertSame(
+            <<<HTML
+            <label class="default-class"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->render(),
+            ),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(Label::class, []);
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label hidden></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->hidden(true)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label id="test-id"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->id('test-id')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label lang="es"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->lang('es')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label lang="es"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->lang(Language::SPANISH)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()
+                    ->addAriaAttribute('label', 'Close')
+                    ->removeAriaAttribute('label')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()
+                    ->addAttribute('data-test', 'value')
+                    ->removeAttribute('data-test')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()
+                    ->addDataAttribute('value', 'test')
+                    ->removeDataAttribute('value')
+                    ->render(),
+            ),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label role="button"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->role('button')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label role="button"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->role(Role::BUTTON)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label style='color: red;'></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->style('color: red;')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label class="text-muted"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->addThemeProvider('muted', DefaultThemeProvider::class)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label title="value"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->title('value')->render(),
+            ),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                (string) Label::tag(),
+            ),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label translate="no"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->translate(false)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label translate="no"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag()->translate(Translate::NO)->render(),
+            ),
+            "Failed asserting that element renders correctly with 'translate' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(Label::class, ['class' => 'from-global', 'id' => 'id-global']);
+
+        self::assertSame(
+            <<<HTML
+            <label class="from-global" id="id-user"></label>
+            HTML,
+            LineEndingNormalizer::normalize(
+                Label::tag(['id' => 'id-user'])->render(),
+            ),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(Label::class, []);
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
