### PR TITLE
feat(form): Add `InputHidden` class for HTML `<input type="hidden">` element with attributes and rendering capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Enh #29: Add `InputPassword` class for HTML `<input type="password">` element with attributes and rendering capabilities (@terabytesoftw)
 - Bug #30: Update parameter descriptions to clarify usage for form attributes and input elements (@terabytesoftw)
 - Enh #31: Add `Label` class for HTML `<label>` element with attributes and rendering capabilities (@terabytesoftw)
+- Enh #32: Add `InputHidden` class for HTML `<input type="hidden">` element with attributes and rendering capabilities (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Form/InputHidden.php
+++ b/src/Form/InputHidden.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form;
+
+use UIAwesome\Html\Attribute\Form\{HasAutocomplete, HasForm};
+use UIAwesome\Html\Attribute\HasValue;
+use UIAwesome\Html\Attribute\Values\Type;
+use UIAwesome\Html\Core\Element\BaseInput;
+use UIAwesome\Html\Interop\{VoidInterface, Voids};
+
+/**
+ * Renders the HTML `<input type="hidden">` element.
+ *
+ * The `<input type="hidden">` defines a hidden input field.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Form\InputHidden::tag()
+ *     ->name('csrf_token')
+ *     ->value('1234567890')
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/hidden
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class InputHidden extends BaseInput
+{
+    use HasAutocomplete;
+    use HasForm;
+    use HasValue;
+
+    /**
+     * Returns the tag enumeration for the `<input>` element.
+     *
+     * @return VoidInterface Tag enumeration instance for `<input>`.
+     */
+    protected function getTag(): VoidInterface
+    {
+        return Voids::INPUT;
+    }
+
+    /**
+     * Returns the default configuration for the input element.
+     *
+     * @return array Default configuration array with method calls as keys.
+     *
+     * @phpstan-return array<string, mixed>
+     */
+    protected function loadDefault(): array
+    {
+        return parent::loadDefault() + ['type' => [Type::HIDDEN]];
+    }
+
+    /**
+     * Renders the `<input>` element with its attributes.
+     *
+     * @return string Rendered HTML for the `<input>` element.
+     */
+    protected function run(): string
+    {
+        return $this->buildElement();
+    }
+}

--- a/tests/Form/InputHiddenTest.php
+++ b/tests/Form/InputHiddenTest.php
@@ -382,9 +382,9 @@ final class InputHiddenTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="inputhidden-" type="hidden" role="textbox">
+            <input id="inputhidden-" type="hidden" role="presentation">
             HTML,
-            InputHidden::tag()->id('inputhidden-')->role('textbox')->render(),
+            InputHidden::tag()->id('inputhidden-')->role('presentation')->render(),
             "Failed asserting that element renders correctly with 'role' attribute.",
         );
     }
@@ -393,9 +393,9 @@ final class InputHiddenTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <input id="inputhidden-" type="hidden" role="textbox">
+            <input id="inputhidden-" type="hidden" role="presentation">
             HTML,
-            InputHidden::tag()->id('inputhidden-')->role(Role::TEXTBOX)->render(),
+            InputHidden::tag()->id('inputhidden-')->role(Role::PRESENTATION)->render(),
             "Failed asserting that element renders correctly with 'role' attribute using enum.",
         );
     }

--- a/tests/Form/InputHiddenTest.php
+++ b/tests/Form/InputHiddenTest.php
@@ -1,0 +1,489 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Form;
+
+use PHPForge\Support\LineEndingNormalizer;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{Aria, Autocomplete, Data, Direction, GlobalAttribute, Language, Role, Translate};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Form\InputHidden;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see InputHidden} hidden input behavior.
+ *
+ * Test coverage.
+ * - Applies global and custom attributes, including `aria-*`, `data-*`, and enum-backed values.
+ * - Applies input-hidden-specific attributes (`autocomplete`, `form`, `name`, `value`) and renders expected output.
+ * - Renders attributes and string casting for a void element.
+ * - Resolves default and theme providers, including global defaults and user overrides.
+ *
+ * {@see InputHidden} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('html')]
+#[Group('form')]
+final class InputHiddenTest extends TestCase
+{
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'default',
+            InputHidden::tag()->getAttribute('data-test', 'default'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" accesskey="k">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->accesskey('k')->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" aria-label="Hidden input">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->addAriaAttribute('label', 'Hidden input')->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" aria-hidden="true">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->addAriaAttribute(Aria::HIDDEN, true)->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" data-test="value">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->addAttribute('data-test', 'value')->render(),
+            "Failed asserting that element renders correctly with 'addAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" title="Hidden input">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->addAttribute(GlobalAttribute::TITLE, 'Hidden input')->render(),
+            "Failed asserting that element renders correctly with 'addAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" data-hidden="value">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->addDataAttribute('hidden', 'value')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" data-value="test">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->addDataAttribute(Data::VALUE, 'test')->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" aria-controls="hidden-picker" aria-label="Select a hidden">
+            HTML,
+            InputHidden::tag()
+                ->id('inputhidden-')
+                ->ariaAttributes([
+                    'controls' => 'hidden-picker',
+                    'label' => 'Select a hidden',
+                ])
+                ->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="hidden-input" id="inputhidden-" type="hidden">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->attributes(['class' => 'hidden-input'])->render(),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAutocomplete(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" autocomplete="on">
+            HTML,
+            InputHidden::tag()->autocomplete('on')->id('inputhidden-')->render(),
+            "Failed asserting that element renders correctly with 'autocomplete' attribute.",
+        );
+    }
+
+    public function testRenderWithAutocompleteUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" autocomplete="on">
+            HTML,
+            InputHidden::tag()->autocomplete(Autocomplete::ON)->id('inputhidden-')->render(),
+            "Failed asserting that element renders correctly with 'autocomplete' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="hidden-input" id="inputhidden-" type="hidden">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->class('hidden-input')->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" data-hidden="value">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->dataAttributes(['hidden' => 'value'])->render(),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputhidden-" type="hidden">
+            HTML,
+            InputHidden::tag(['class' => 'default-class'])->id('inputhidden-')->render(),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputhidden-" type="hidden" title="default-title">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->addDefaultProvider(DefaultProvider::class)->render(),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->render(),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" dir="ltr">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->dir('ltr')->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" dir="ltr">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->dir(Direction::LTR)->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithDisabled(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" disabled>
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->disabled(true)->render(),
+            "Failed asserting that element renders correctly with 'disabled' attribute.",
+        );
+    }
+
+    public function testRenderWithForm(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" form="form-id">
+            HTML,
+            InputHidden::tag()->form('form-id')->id('inputhidden-')->render(),
+            "Failed asserting that element renders correctly with 'form' attribute.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(InputHidden::class, ['class' => 'default-class']);
+
+        self::assertStringContainsString(
+            'class="default-class"',
+            InputHidden::tag()->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(InputHidden::class, []);
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" hidden>
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->hidden(true)->render(),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="hidden-input" type="hidden">
+            HTML,
+            InputHidden::tag()->id('hidden-input')->render(),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" lang="en">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->lang('en')->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" lang="en">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->lang(Language::ENGLISH)->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithName(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" name="csrf_token" type="hidden">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->name('csrf_token')->render(),
+            "Failed asserting that element renders correctly with 'name' attribute.",
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden">
+            HTML,
+            InputHidden::tag()
+                ->id('inputhidden-')
+                ->addAriaAttribute('label', 'Close')
+                ->removeAriaAttribute('label')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden">
+            HTML,
+            InputHidden::tag()
+                ->id('inputhidden-')
+                ->addAttribute('data-test', 'value')
+                ->removeAttribute('data-test')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden">
+            HTML,
+            InputHidden::tag()
+                ->id('inputhidden-')
+                ->addDataAttribute('value', 'test')
+                ->removeDataAttribute('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" role="textbox">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->role('textbox')->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" role="textbox">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->role(Role::TEXTBOX)->render(),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" style='display: none;'>
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->style('display: none;')->render(),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="text-muted" id="inputhidden-" type="hidden">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->addThemeProvider('muted', DefaultThemeProvider::class)->render(),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" title="Hidden input">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->title('Hidden input')->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertStringContainsString(
+            'type="hidden"',
+            LineEndingNormalizer::normalize((string) InputHidden::tag()),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" translate="no">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->translate(false)->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" translate="no">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->translate(Translate::NO)->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(InputHidden::class, ['class' => 'from-global', 'id' => 'id-global']);
+
+        $output = InputHidden::tag(['id' => 'id-user'])->render();
+
+        self::assertStringContainsString('class="from-global"', $output);
+        self::assertStringContainsString('id="id-user"', $output);
+
+        SimpleFactory::setDefaults(InputHidden::class, []);
+    }
+
+    public function testRenderWithValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputhidden-" type="hidden" value="1234567890">
+            HTML,
+            InputHidden::tag()->id('inputhidden-')->value('1234567890')->render(),
+            "Failed asserting that element renders correctly with 'value' attribute.",
+        );
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
