### PR TITLE
fix(list): Remove redundant `afterRun()` method from `Dl`, `Ol`, and `Ul` classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Enh #35: Add `InputRadio` class for HTML `<input type="radio">` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #36: Add `InputNumber` class for HTML `<input type="number">` element with attributes and rendering capabilities (@terabytesoftw)
 - Bug #37: Apply last changes from `ui-awesome/html-core` package to `ui-awesome/html` package (@terabytesoftw)
+- Bug #38: Remove redundant `afterRun()` method from `Dl`, `Ol`, and `Ul` classes (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/List/Dl.php
+++ b/src/List/Dl.php
@@ -6,7 +6,6 @@ namespace UIAwesome\Html\List;
 
 use Stringable;
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Helper\LineBreakNormalizer;
 use UIAwesome\Html\Interop\{BlockInterface, Lists};
 
 /**

--- a/src/List/Dl.php
+++ b/src/List/Dl.php
@@ -72,20 +72,6 @@ final class Dl extends BaseBlock
     }
 
     /**
-     * Cleans up the output after rendering the block element.
-     *
-     * Removes excessive consecutive newlines from the rendered output to ensure clean HTML structure.
-     *
-     * @param string $result Rendered HTML output.
-     *
-     * @return string Cleaned HTML output with excessive newlines removed.
-     */
-    protected function afterRun(string $result): string
-    {
-        return parent::afterRun(LineBreakNormalizer::normalize($result));
-    }
-
-    /**
      * Returns the tag enumeration for the `<dl>` element.
      *
      * @return BlockInterface Tag enumeration instance for `<dl>`.

--- a/src/List/Ol.php
+++ b/src/List/Ol.php
@@ -6,7 +6,6 @@ namespace UIAwesome\Html\List;
 
 use Stringable;
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Helper\LineBreakNormalizer;
 use UIAwesome\Html\Interop\{BlockInterface, Lists};
 use UIAwesome\Html\List\Attribute\{HasReversed, HasStart};
 

--- a/src/List/Ol.php
+++ b/src/List/Ol.php
@@ -88,20 +88,6 @@ final class Ol extends BaseBlock
     }
 
     /**
-     * Cleans up the output after rendering the block element.
-     *
-     * Removes excessive consecutive newlines from the rendered output to ensure clean HTML structure.
-     *
-     * @param string $result Rendered HTML output.
-     *
-     * @return string Cleaned HTML output with excessive newlines removed.
-     */
-    protected function afterRun(string $result): string
-    {
-        return parent::afterRun(LineBreakNormalizer::normalize($result));
-    }
-
-    /**
      * Returns the tag enumeration for the `<ol>` element.
      *
      * @return BlockInterface Tag enumeration instance for `<ol>`.

--- a/src/List/Ul.php
+++ b/src/List/Ul.php
@@ -6,7 +6,6 @@ namespace UIAwesome\Html\List;
 
 use Stringable;
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Helper\LineBreakNormalizer;
 use UIAwesome\Html\Interop\{BlockInterface, Lists};
 
 /**

--- a/src/List/Ul.php
+++ b/src/List/Ul.php
@@ -82,20 +82,6 @@ final class Ul extends BaseBlock
     }
 
     /**
-     * Cleans up the output after rendering the block element.
-     *
-     * Removes excessive consecutive newlines from the rendered output to ensure clean HTML structure.
-     *
-     * @param string $result Rendered HTML output.
-     *
-     * @return string Cleaned HTML output with excessive newlines removed.
-     */
-    protected function afterRun(string $result): string
-    {
-        return parent::afterRun(LineBreakNormalizer::normalize($result));
-    }
-
-    /**
      * Returns the tag enumeration for the `<ul>` element.
      *
      * @return BlockInterface Tag enumeration instance for `<ul>`.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
