### PR TITLE
fix(tests): Refactor tests to use `assertSame()` for rendering with `testRenderWithGlobalDefaultsAreApplied()` and `testRenderWithUserOverridesGlobalDefaults()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Bug #37: Apply last changes from `ui-awesome/html-core` package to `ui-awesome/html` package (@terabytesoftw)
 - Bug #38: Remove redundant `afterRun()` method from `Dl`, `Ol`, and `Ul` classes (@terabytesoftw)
 - Enh #39: Add `InputMonth` class for HTML `<input type="month">` element with attributes and rendering capabilities (@terabytesoftw)
-- Bug #40: Refactor tests to use `assertSame()` for rendering with `testRenderWithGlobalDefaultsAreApplied()` and `testRenderWithGlobalDefaultsAreApplied()` (@terabytesoftw)
+- Bug #40: Refactor tests to use `assertSame()` for rendering with `testRenderWithGlobalDefaultsAreApplied()` and `testRenderWithUserOverridesGlobalDefaults()` (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Bug #37: Apply last changes from `ui-awesome/html-core` package to `ui-awesome/html` package (@terabytesoftw)
 - Bug #38: Remove redundant `afterRun()` method from `Dl`, `Ol`, and `Ul` classes (@terabytesoftw)
 - Enh #39: Add `InputMonth` class for HTML `<input type="month">` element with attributes and rendering capabilities (@terabytesoftw)
-- Enh #40: Refactor tests to use `assertSame()` for rendering with `testRenderWithGlobalDefaultsAreApplied()` and `testRenderWithGlobalDefaultsAreApplied()` (@terabytesoftw)
+- Bug #40: Refactor tests to use `assertSame()` for rendering with `testRenderWithGlobalDefaultsAreApplied()` and `testRenderWithGlobalDefaultsAreApplied()` (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Bug #37: Apply last changes from `ui-awesome/html-core` package to `ui-awesome/html` package (@terabytesoftw)
 - Bug #38: Remove redundant `afterRun()` method from `Dl`, `Ol`, and `Ul` classes (@terabytesoftw)
 - Enh #39: Add `InputMonth` class for HTML `<input type="month">` element with attributes and rendering capabilities (@terabytesoftw)
+- Enh #40: Refactor tests to use `assertSame()` for rendering with `testRenderWithGlobalDefaultsAreApplied()` and `testRenderWithGlobalDefaultsAreApplied()` (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/tests/Form/InputCheckboxTest.php
+++ b/tests/Form/InputCheckboxTest.php
@@ -636,15 +636,25 @@ final class InputCheckboxTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputCheckbox::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputCheckbox::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputCheckbox::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputcheckbox" type="checkbox">
+            HTML,
+            InputCheckbox::tag()
+                ->id('inputcheckbox')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputCheckbox::class, []);
+        SimpleFactory::setDefaults(
+            InputCheckbox::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -1089,14 +1099,26 @@ final class InputCheckboxTest extends TestCase
 
     public function testRenderWithUserOverridesGlobalDefaults(): void
     {
-        SimpleFactory::setDefaults(InputCheckbox::class, ['class' => 'from-global', 'id' => 'id-global']);
+        SimpleFactory::setDefaults(
+            InputCheckbox::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
 
-        $output = InputCheckbox::tag(['id' => 'id-user'])->render();
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="checkbox">
+            HTML,
+            InputCheckbox::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
-
-        SimpleFactory::setDefaults(InputCheckbox::class, []);
+        SimpleFactory::setDefaults(
+            InputCheckbox::class,
+            [],
+        );
     }
 
     public function testRenderWithValue(): void

--- a/tests/Form/InputHiddenTest.php
+++ b/tests/Form/InputHiddenTest.php
@@ -435,15 +435,25 @@ final class InputHiddenTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputHidden::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputHidden::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputHidden::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputhidden" type="hidden">
+            HTML,
+            InputHidden::tag()
+                ->id('inputhidden')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputHidden::class, []);
+        SimpleFactory::setDefaults(
+            InputHidden::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -607,9 +617,7 @@ final class InputHiddenTest extends TestCase
             <<<HTML
             <input type="hidden">
             HTML,
-            InputHidden::tag()
-                ->id(null)
-                ->render(),
+            (string) InputHidden::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -638,14 +646,26 @@ final class InputHiddenTest extends TestCase
 
     public function testRenderWithUserOverridesGlobalDefaults(): void
     {
-        SimpleFactory::setDefaults(InputHidden::class, ['class' => 'from-global', 'id' => 'id-global']);
+        SimpleFactory::setDefaults(
+            InputHidden::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
 
-        $output = InputHidden::tag(['id' => 'id-user'])->render();
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="hidden">
+            HTML,
+            InputHidden::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
-
-        SimpleFactory::setDefaults(InputHidden::class, []);
+        SimpleFactory::setDefaults(
+            InputHidden::class,
+            [],
+        );
     }
 
     public function testRenderWithValue(): void

--- a/tests/Form/InputNumberTest.php
+++ b/tests/Form/InputNumberTest.php
@@ -506,15 +506,25 @@ final class InputNumberTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputNumber::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputNumber::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputNumber::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputnumber" type="number">
+            HTML,
+            InputNumber::tag()
+                ->id('inputnumber')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputNumber::class, []);
+        SimpleFactory::setDefaults(
+            InputNumber::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -848,9 +858,7 @@ final class InputNumberTest extends TestCase
             <<<HTML
             <input type="number">
             HTML,
-            InputNumber::tag()
-                ->id(null)
-                ->render(),
+            (string) InputNumber::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -885,12 +893,21 @@ final class InputNumberTest extends TestCase
 
     public function testRenderWithUserOverridesGlobalDefaults(): void
     {
-        SimpleFactory::setDefaults(InputNumber::class, ['class' => 'from-global', 'id' => 'id-global']);
+        SimpleFactory::setDefaults(
+            InputNumber::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
 
-        $output = InputNumber::tag(['id' => 'id-user'])->render();
-
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="number">
+            HTML,
+            InputNumber::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
         SimpleFactory::setDefaults(InputNumber::class, []);
     }

--- a/tests/Form/InputPasswordTest.php
+++ b/tests/Form/InputPasswordTest.php
@@ -458,15 +458,25 @@ final class InputPasswordTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputPassword::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputPassword::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputPassword::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputpassword" type="password">
+            HTML,
+            InputPassword::tag()
+                ->id('inputpassword')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputPassword::class, []);
+        SimpleFactory::setDefaults(
+            InputPassword::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -740,9 +750,7 @@ final class InputPasswordTest extends TestCase
             <<<HTML
             <input type="password">
             HTML,
-            InputPassword::tag()
-                ->id(null)
-                ->render(),
+            (string) InputPassword::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -771,14 +779,26 @@ final class InputPasswordTest extends TestCase
 
     public function testRenderWithUserOverridesGlobalDefaults(): void
     {
-        SimpleFactory::setDefaults(InputPassword::class, ['class' => 'from-global', 'id' => 'id-global']);
+        SimpleFactory::setDefaults(
+            InputPassword::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
 
-        $output = InputPassword::tag(['id' => 'id-user'])->render();
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="password">
+            HTML,
+            InputPassword::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
-
-        SimpleFactory::setDefaults(InputPassword::class, []);
+        SimpleFactory::setDefaults(
+            InputPassword::class,
+            [],
+        );
     }
 
     public function testRenderWithValue(): void

--- a/tests/Form/InputRadioTest.php
+++ b/tests/Form/InputRadioTest.php
@@ -646,15 +646,25 @@ final class InputRadioTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputRadio::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputRadio::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputRadio::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputradio" type="radio">
+            HTML,
+            InputRadio::tag()
+                ->id('inputradio')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputRadio::class, []);
+        SimpleFactory::setDefaults(
+            InputRadio::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -1026,9 +1036,7 @@ final class InputRadioTest extends TestCase
             <<<HTML
             <input type="radio">
             HTML,
-            InputRadio::tag()
-                ->id(null)
-                ->render(),
+            (string) InputRadio::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -1101,12 +1109,21 @@ final class InputRadioTest extends TestCase
 
     public function testRenderWithUserOverridesGlobalDefaults(): void
     {
-        SimpleFactory::setDefaults(InputRadio::class, ['class' => 'from-global', 'id' => 'id-global']);
+        SimpleFactory::setDefaults(
+            InputRadio::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
 
-        $output = InputRadio::tag(['id' => 'id-user'])->render();
-
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="radio">
+            HTML,
+            InputRadio::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
         SimpleFactory::setDefaults(InputRadio::class, []);
     }

--- a/tests/Form/InputRangeTest.php
+++ b/tests/Form/InputRangeTest.php
@@ -447,15 +447,25 @@ final class InputRangeTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputRange::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputRange::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputRange::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputrange" type="range">
+            HTML,
+            InputRange::tag()
+                ->id('inputrange')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputRange::class, []);
+        SimpleFactory::setDefaults(
+            InputRange::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -700,9 +710,7 @@ final class InputRangeTest extends TestCase
             <<<HTML
             <input type="range">
             HTML,
-            InputRange::tag()
-                ->id(null)
-                ->render(),
+            (string) InputRange::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -731,14 +739,26 @@ final class InputRangeTest extends TestCase
 
     public function testRenderWithUserOverridesGlobalDefaults(): void
     {
-        SimpleFactory::setDefaults(InputRange::class, ['class' => 'from-global', 'id' => 'id-global']);
+        SimpleFactory::setDefaults(
+            InputRange::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
 
-        $output = InputRange::tag(['id' => 'id-user'])->render();
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="range">
+            HTML,
+            InputRange::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
-
-        SimpleFactory::setDefaults(InputRange::class, []);
+        SimpleFactory::setDefaults(
+            InputRange::class,
+            [],
+        );
     }
 
     public function testRenderWithValue(): void

--- a/tests/Form/InputResetTest.php
+++ b/tests/Form/InputResetTest.php
@@ -414,15 +414,25 @@ final class InputResetTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputReset::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputReset::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputReset::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputreset" type="reset">
+            HTML,
+            InputReset::tag()
+                ->id('inputreset')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputReset::class, []);
+        SimpleFactory::setDefaults(
+            InputReset::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -628,10 +638,13 @@ final class InputResetTest extends TestCase
     {
         SimpleFactory::setDefaults(InputReset::class, ['class' => 'from-global', 'id' => 'id-global']);
 
-        $output = InputReset::tag(['id' => 'id-user'])->render();
-
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="reset">
+            HTML,
+            InputReset::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
         SimpleFactory::setDefaults(InputReset::class, []);
     }

--- a/tests/Form/InputSearchTest.php
+++ b/tests/Form/InputSearchTest.php
@@ -459,15 +459,25 @@ final class InputSearchTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputSearch::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputSearch::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputSearch::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputsearch" type="search">
+            HTML,
+            InputSearch::tag()
+                ->id('inputsearch')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputSearch::class, []);
+        SimpleFactory::setDefaults(
+            InputSearch::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -741,9 +751,7 @@ final class InputSearchTest extends TestCase
             <<<HTML
             <input type="search">
             HTML,
-            InputSearch::tag()
-                ->id(null)
-                ->render(),
+            (string) InputSearch::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -774,10 +782,13 @@ final class InputSearchTest extends TestCase
     {
         SimpleFactory::setDefaults(InputSearch::class, ['class' => 'from-global', 'id' => 'id-global']);
 
-        $output = InputSearch::tag(['id' => 'id-user'])->render();
-
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="search">
+            HTML,
+            InputSearch::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
         SimpleFactory::setDefaults(InputSearch::class, []);
     }

--- a/tests/Form/InputSubmitTest.php
+++ b/tests/Form/InputSubmitTest.php
@@ -502,15 +502,25 @@ final class InputSubmitTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputSubmit::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputSubmit::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputSubmit::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputsubmit" type="submit">
+            HTML,
+            InputSubmit::tag()
+                ->id('inputsubmit')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputSubmit::class, []);
+        SimpleFactory::setDefaults(
+            InputSubmit::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -685,9 +695,7 @@ final class InputSubmitTest extends TestCase
             <<<HTML
             <input type="submit">
             HTML,
-            InputSubmit::tag()
-                ->id(null)
-                ->render(),
+            (string) InputSubmit::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -718,10 +726,13 @@ final class InputSubmitTest extends TestCase
     {
         SimpleFactory::setDefaults(InputSubmit::class, ['class' => 'from-global', 'id' => 'id-global']);
 
-        $output = InputSubmit::tag(['id' => 'id-user'])->render();
-
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="submit">
+            HTML,
+            InputSubmit::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
         SimpleFactory::setDefaults(InputSubmit::class, []);
     }

--- a/tests/Form/InputTelTest.php
+++ b/tests/Form/InputTelTest.php
@@ -449,15 +449,25 @@ final class InputTelTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputTel::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputTel::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputTel::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputtel" type="tel">
+            HTML,
+            InputTel::tag()
+                ->id('inputtel')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputTel::class, []);
+        SimpleFactory::setDefaults(
+            InputTel::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -731,9 +741,7 @@ final class InputTelTest extends TestCase
             <<<HTML
             <input type="tel">
             HTML,
-            InputTel::tag()
-                ->id(null)
-                ->render(),
+            (string) InputTel::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -764,10 +772,13 @@ final class InputTelTest extends TestCase
     {
         SimpleFactory::setDefaults(InputTel::class, ['class' => 'from-global', 'id' => 'id-global']);
 
-        $output = InputTel::tag(['id' => 'id-user'])->render();
-
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="tel">
+            HTML,
+            InputTel::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
         SimpleFactory::setDefaults(InputTel::class, []);
     }

--- a/tests/Form/InputTextTest.php
+++ b/tests/Form/InputTextTest.php
@@ -459,15 +459,25 @@ final class InputTextTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputText::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputText::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputText::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputtext" type="text">
+            HTML,
+            InputText::tag()
+                ->id('inputtext')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputText::class, []);
+        SimpleFactory::setDefaults(
+            InputText::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -741,9 +751,7 @@ final class InputTextTest extends TestCase
             <<<HTML
             <input type="text">
             HTML,
-            InputText::tag()
-                ->id(null)
-                ->render(),
+            (string) InputText::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -774,10 +782,13 @@ final class InputTextTest extends TestCase
     {
         SimpleFactory::setDefaults(InputText::class, ['class' => 'from-global', 'id' => 'id-global']);
 
-        $output = InputText::tag(['id' => 'id-user'])->render();
-
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="text">
+            HTML,
+            InputText::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
         SimpleFactory::setDefaults(InputText::class, []);
     }

--- a/tests/Form/InputTimeTest.php
+++ b/tests/Form/InputTimeTest.php
@@ -447,15 +447,25 @@ final class InputTimeTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputTime::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputTime::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputTime::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputtime" type="time">
+            HTML,
+            InputTime::tag()
+                ->id('inputtime')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputTime::class, []);
+        SimpleFactory::setDefaults(
+            InputTime::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -722,9 +732,7 @@ final class InputTimeTest extends TestCase
             <<<HTML
             <input type="time">
             HTML,
-            InputTime::tag()
-                ->id(null)
-                ->render(),
+            (string) InputTime::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -755,10 +763,13 @@ final class InputTimeTest extends TestCase
     {
         SimpleFactory::setDefaults(InputTime::class, ['class' => 'from-global', 'id' => 'id-global']);
 
-        $output = InputTime::tag(['id' => 'id-user'])->render();
-
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="time">
+            HTML,
+            InputTime::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
         SimpleFactory::setDefaults(InputTime::class, []);
     }

--- a/tests/Form/InputUrlTest.php
+++ b/tests/Form/InputUrlTest.php
@@ -449,15 +449,25 @@ final class InputUrlTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputUrl::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputUrl::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputUrl::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputurl" type="url">
+            HTML,
+            InputUrl::tag()
+                ->id('inputurl')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputUrl::class, []);
+        SimpleFactory::setDefaults(
+            InputUrl::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -731,9 +741,7 @@ final class InputUrlTest extends TestCase
             <<<HTML
             <input type="url">
             HTML,
-            InputUrl::tag()
-                ->id(null)
-                ->render(),
+            (string) InputUrl::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -764,10 +772,13 @@ final class InputUrlTest extends TestCase
     {
         SimpleFactory::setDefaults(InputUrl::class, ['class' => 'from-global', 'id' => 'id-global']);
 
-        $output = InputUrl::tag(['id' => 'id-user'])->render();
-
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="url">
+            HTML,
+            InputUrl::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
         SimpleFactory::setDefaults(InputUrl::class, []);
     }

--- a/tests/Form/InputWeekTest.php
+++ b/tests/Form/InputWeekTest.php
@@ -447,15 +447,25 @@ final class InputWeekTest extends TestCase
 
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
-        SimpleFactory::setDefaults(InputWeek::class, ['class' => 'default-class']);
+        SimpleFactory::setDefaults(
+            InputWeek::class,
+            ['class' => 'default-class'],
+        );
 
-        self::assertStringContainsString(
-            'class="default-class"',
-            InputWeek::tag()->render(),
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputweek" type="week">
+            HTML,
+            InputWeek::tag()
+                ->id('inputweek')
+                ->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
-        SimpleFactory::setDefaults(InputWeek::class, []);
+        SimpleFactory::setDefaults(
+            InputWeek::class,
+            [],
+        );
     }
 
     public function testRenderWithHidden(): void
@@ -722,9 +732,7 @@ final class InputWeekTest extends TestCase
             <<<HTML
             <input type="week">
             HTML,
-            InputWeek::tag()
-                ->id(null)
-                ->render(),
+            (string) InputWeek::tag()->id(null),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }
@@ -755,10 +763,13 @@ final class InputWeekTest extends TestCase
     {
         SimpleFactory::setDefaults(InputWeek::class, ['class' => 'from-global', 'id' => 'id-global']);
 
-        $output = InputWeek::tag(['id' => 'id-user'])->render();
-
-        self::assertStringContainsString('class="from-global"', $output);
-        self::assertStringContainsString('id="id-user"', $output);
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="week">
+            HTML,
+            InputWeek::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
 
         SimpleFactory::setDefaults(InputWeek::class, []);
     }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
