### PR TITLE
fix(mixin): Better naming for `CanBeChecked` to `HasUnchecked` and update phpdoc `BaseChoice` classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Bug #42: Fix messages in `assert()` methods and code style (@terabytesoftw)
 - Bug #43: Update `ui-awesome/html-helper` to version `^0.7` and `ui-awesome/html-mixin` to version `^0.4` in `composer.json` and apply necessary changes to `src` and `tests` directories (@terabytesoftw)
 - Bug #44: Update last modified from `ui-awesome/html-attribute` in related classes (@terabytesoftw)
-- Bug #45: Better naming for `CanBeChecked` to `HasUnchecked` and update phpdoc `BaseChoice` classes (@terabytesoftw)
+- Bug #45: Better naming for `CanBeUnchecked` to `HasUnchecked` and update phpdoc `BaseChoice` classes (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Bug #42: Fix messages in `assert()` methods and code style (@terabytesoftw)
 - Bug #43: Update `ui-awesome/html-helper` to version `^0.7` and `ui-awesome/html-mixin` to version `^0.4` in `composer.json` and apply necessary changes to `src` and `tests` directories (@terabytesoftw)
 - Bug #44: Update last modified from `ui-awesome/html-attribute` in related classes (@terabytesoftw)
+- Bug #45: Better naming for `CanBeChecked` to `HasUnchecked` and update phpdoc `BaseChoice` classes (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Form/Base/BaseChoice.php
+++ b/src/Form/Base/BaseChoice.php
@@ -10,18 +10,29 @@ use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Core\Element\BaseInput;
 use UIAwesome\Html\Core\Html;
 use UIAwesome\Html\Form\InputHidden;
-use UIAwesome\Html\Form\Mixin\{CanBeEnclosedByLabel, CanBeUnchecked, HasCheckedState};
+use UIAwesome\Html\Form\Mixin\{CanBeEnclosedByLabel, HasUnchecked, HasCheckedState};
 use UIAwesome\Html\Mixin\HasLabelCollection;
 use UIAwesome\Html\Phrasing\Label;
 
 use function array_key_exists;
 
+/**
+ * Provides a shared base for checkbox and radio input elements.
+ *
+ * Handles unchecked hidden input rendering, label rendering (enclosed or separate), and checked-state and value
+ * attributes through mixins.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
 abstract class BaseChoice extends BaseInput
 {
     use CanBeAutofocus;
     use CanBeEnclosedByLabel;
     use CanBeRequired;
-    use CanBeUnchecked;
+    use HasUnchecked;
     use HasCheckedState;
     use HasLabelCollection;
     use HasTabindex;

--- a/src/Form/Base/BaseChoice.php
+++ b/src/Form/Base/BaseChoice.php
@@ -32,10 +32,10 @@ abstract class BaseChoice extends BaseInput
     use CanBeAutofocus;
     use CanBeEnclosedByLabel;
     use CanBeRequired;
-    use HasUnchecked;
     use HasCheckedState;
     use HasLabelCollection;
     use HasTabindex;
+    use HasUnchecked;
     use HasValue;
 
     /**

--- a/src/Form/Base/BaseChoice.php
+++ b/src/Form/Base/BaseChoice.php
@@ -10,7 +10,7 @@ use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Core\Element\BaseInput;
 use UIAwesome\Html\Core\Html;
 use UIAwesome\Html\Form\InputHidden;
-use UIAwesome\Html\Form\Mixin\{CanBeEnclosedByLabel, HasUnchecked, HasCheckedState};
+use UIAwesome\Html\Form\Mixin\{CanBeEnclosedByLabel, HasCheckedState, HasUnchecked};
 use UIAwesome\Html\Mixin\HasLabelCollection;
 use UIAwesome\Html\Phrasing\Label;
 

--- a/src/Form/Mixin/HasUnchecked.php
+++ b/src/Form/Mixin/HasUnchecked.php
@@ -13,7 +13,7 @@ use UnitEnum;
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-trait CanBeUnchecked
+trait HasUnchecked
 {
     /**
      * Value to be submitted when the element is not checked.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
