### PR TITLE
feat(form): Add `InputFile` class for HTML `<input type="file">` element with attributes and rendering capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Bug #43: Update `ui-awesome/html-helper` to version `^0.7` and `ui-awesome/html-mixin` to version `^0.4` in `composer.json` and apply necessary changes to `src` and `tests` directories (@terabytesoftw)
 - Bug #44: Update last modified from `ui-awesome/html-attribute` in related classes (@terabytesoftw)
 - Bug #45: Better naming for `CanBeUnchecked` to `HasUnchecked` and update phpdoc `BaseChoice` classes (@terabytesoftw)
+- Enh #46: Add `InputFile` class for HTML `<input type="file">` element with attributes and rendering capabilities (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Form/Attribute/HasCapture.php
+++ b/src/Form/Attribute/HasCapture.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+use Stringable;
+use UIAwesome\Html\Attribute\Values\Attribute;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the `capture` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/capture
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasCapture
+{
+    /**
+     * Sets the `capture` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\InputFile::tag()->capture('user')->render();
+     * echo \UIAwesome\Html\Form\InputFile::tag()->capture('environment')->render();
+     * ```
+     *
+     * @param string|Stringable|UnitEnum|null $value Capture value, or `null` to remove the attribute.
+     *
+     * @return static New instance with the updated `capture` attribute.
+     */
+    public function capture(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->setAttribute(Attribute::CAPTURE, $value);
+    }
+}

--- a/src/Form/InputFile.php
+++ b/src/Form/InputFile.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form;
+
+use UIAwesome\Html\Attribute\Form\{CanBeMultiple, CanBeRequired, HasAccept, HasForm};
+use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
+use UIAwesome\Html\Attribute\Values\Type;
+use UIAwesome\Html\Core\Element\BaseInput;
+use UIAwesome\Html\Form\Attribute\HasCapture;
+use UIAwesome\Html\Form\Mixin\HasUnchecked;
+use UIAwesome\Html\Helper\Naming;
+use UIAwesome\Html\Interop\{VoidInterface, Voids};
+
+/**
+ * Renders the HTML `<input type="file">` element.
+ *
+ * The `<input type="file">` element allows the user to choose one or more files from their device storage. Once chosen,
+ * the files can be uploaded to a server using form submission, or manipulated using JavaScript code and the File API.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Form\InputFile::tag()
+ *     ->accept('image/png, image/jpeg')
+ *     ->name('avatar')
+ *     ->render();
+ * echo \UIAwesome\Html\Form\InputFile::tag()
+ *     ->multiple(true)
+ *     ->name('photos')
+ *     ->render();
+ * echo \UIAwesome\Html\Form\InputFile::tag()
+ *     ->capture(\UIAwesome\Html\Form\Values\Capture::USER)
+ *     ->name('video')
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/file
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class InputFile extends BaseInput
+{
+    use CanBeAutofocus;
+    use CanBeMultiple;
+    use CanBeRequired;
+    use HasAccept;
+    use HasCapture;
+    use HasForm;
+    use HasTabindex;
+    use HasUnchecked;
+
+    /**
+     * Returns the array of HTML attributes for the element.
+     *
+     * @return array Attributes array assigned to the element.
+     *
+     * @phpstan-return mixed[]
+     */
+    public function getAttributes(): array
+    {
+        $attributes = parent::getAttributes();
+        $attributes['name'] = $this->generateNameWithMultiple();
+
+        // value attribute is not allowed for the `<input type="file">` element, so we remove it if it exists.
+        unset($attributes['value']);
+
+        return $attributes;
+    }
+
+    /**
+     * Returns the tag enumeration for the `<input>` element.
+     *
+     * @return VoidInterface Tag enumeration instance for `<input>`.
+     */
+    protected function getTag(): VoidInterface
+    {
+        return Voids::INPUT;
+    }
+
+    /**
+     * Returns the default configuration for the input element.
+     *
+     * @return array Default configuration array with method calls as keys.
+     *
+     * @phpstan-return array<string, mixed>
+     */
+    protected function loadDefault(): array
+    {
+        return [
+            'template' => ['{prefix}\n{unchecked}\n{tag}\n{suffix}'],
+            'type' => [Type::FILE],
+        ] + parent::loadDefault();
+    }
+
+    /**
+     * Renders the `<input>` element with its attributes.
+     *
+     * @return string Rendered HTML for the `<input>` element.
+     */
+    protected function run(): string
+    {
+        $uncheckedValue = $this->getUncheckedValue();
+
+        if ($uncheckedValue !== null && $uncheckedValue !== '') {
+            $unchecked = InputHidden::tag()
+                ->id(null)
+                ->name($this->generateNameWithMultiple())
+                ->value($uncheckedValue)
+                ->render();
+        }
+
+        return $this->buildElement(
+            '',
+            [
+                '{unchecked}' => $unchecked ?? '',
+            ],
+        );
+    }
+
+    /**
+     * Generates the name of the input element, adding `[]` if the `multiple` attribute is set.
+     *
+     * @return string The generated name.
+     */
+    private function generateNameWithMultiple(): string
+    {
+        /** @phpstan-var string $name */
+        $name = $this->getAttribute('name', '');
+        $isMultiple = $this->getAttribute('multiple', false);
+
+        if ($isMultiple === false) {
+            return $name;
+        }
+
+        return Naming::generateArrayableName($name);
+    }
+}

--- a/src/Form/Values/Capture.php
+++ b/src/Form/Values/Capture.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Values;
+
+/**
+ * Represents the values for the HTML `capture` attribute.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/capture
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Capture: string
+{
+    /**
+     * The outward-facing camera and/or microphone should be used.
+     */
+    case ENVIRONMENT = 'environment';
+
+    /**
+     * The user-facing camera and/or microphone should be used.
+     */
+    case USER = 'user';
+}

--- a/tests/Form/InputFileTest.php
+++ b/tests/Form/InputFileTest.php
@@ -1,0 +1,888 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Form;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{Aria, Data, Direction, GlobalAttribute, Language, Role, Translate};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Form\InputFile;
+use UIAwesome\Html\Form\Values\Capture;
+use UIAwesome\Html\Interop\Inline;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for the {@see InputFile} class.
+ *
+ * Test coverage.
+ * - Applies global and custom attributes, including `aria-*`, `data-*`, and enum-backed values.
+ * - Applies input-file-specific attributes (`accept`, `capture`, `multiple`, `required`) and renders expected output.
+ * - Renders attributes and string casting for a void element.
+ * - Resolves default and theme providers, including global defaults and user overrides.
+ *
+ * {@see InputFile} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('form')]
+final class InputFileTest extends TestCase
+{
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'default',
+            InputFile::tag()->getAttribute('data-test', 'default'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testRenderWithAccept(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" name="inputfile" type="file" accept="image/*">
+            HTML,
+            InputFile::tag()
+                ->accept('image/*')
+                ->id('inputfile')
+                ->name('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'accept' attribute.",
+        );
+    }
+
+    public function testRenderWithAcceptUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" name="inputfile" type="file" accept=".jpg, .png">
+            HTML,
+            InputFile::tag()
+                ->accept('.jpg, .png')
+                ->id('inputfile')
+                ->name('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'accept' attribute.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" accesskey="k">
+            HTML,
+            InputFile::tag()
+                ->accesskey('k')
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" aria-label="File selector">
+            HTML,
+            InputFile::tag()
+                ->addAriaAttribute('label', 'File selector')
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" aria-hidden="true">
+            HTML,
+            InputFile::tag()
+                ->addAriaAttribute(Aria::HIDDEN, true)
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" aria-describedby="custom-help">
+            HTML,
+            InputFile::tag()
+                ->addAriaAttribute('describedby', 'custom-help')
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that an explicit 'aria-describedby' string value is preserved.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" aria-describedby="inputfile-help">
+            HTML,
+            InputFile::tag()
+                ->addAriaAttribute('describedby', true)
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to "
+            . "'true'.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValueAndIdNull(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input type="file">
+            HTML,
+            InputFile::tag()
+                ->addAriaAttribute('describedby', true)
+                ->id(null)
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true' and 'id'"
+            . " is 'null'.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValueAndPrefixSuffix(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <span>Prefix</span>
+            <input id="inputfile" type="file" aria-describedby="inputfile-help">
+            <span>Suffix</span>
+            HTML,
+            InputFile::tag()
+                ->addAriaAttribute('describedby', true)
+                ->id('inputfile')
+                ->prefix('Prefix')
+                ->prefixTag(Inline::SPAN)
+                ->suffix('Suffix')
+                ->suffixTag(Inline::SPAN)
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true' and "
+            . 'prefix/suffix.',
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValueString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" aria-describedby="inputfile-help">
+            HTML,
+            InputFile::tag()
+                ->addAriaAttribute('describedby', 'true')
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueStringValueAndPrefixSuffix(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <span>Prefix</span>
+            <input id="inputfile" type="file" aria-describedby="inputfile-help">
+            <span>Suffix</span>
+            HTML,
+            InputFile::tag()
+                ->addAriaAttribute('describedby', 'true')
+                ->id('inputfile')
+                ->prefix('Prefix')
+                ->prefixTag(Inline::SPAN)
+                ->suffix('Suffix')
+                ->suffixTag(Inline::SPAN)
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true' and "
+            . 'prefix/suffix.',
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" data-file="value">
+            HTML,
+            InputFile::tag()
+                ->addDataAttribute('file', 'value')
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" data-value="test">
+            HTML,
+            InputFile::tag()
+                ->addDataAttribute(Data::VALUE, 'test')
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" aria-controls="file-picker" aria-label="Select a file">
+            HTML,
+            InputFile::tag()
+                ->ariaAttributes(
+                    [
+                        'controls' => 'file-picker',
+                        'label' => 'Select a file',
+                    ],
+                )
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributesAndAriaDescribedByTrueBooleanValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" aria-describedby="inputfile-help">
+            HTML,
+            InputFile::tag()
+                ->ariaAttributes(['describedby' => true])
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAriaAttributesAndAriaDescribedByTrueStringValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" aria-describedby="inputfile-help">
+            HTML,
+            InputFile::tag()
+                ->ariaAttributes(['describedby' => 'true'])
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="file-input" id="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->attributes(['class' => 'file-input'])
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributesAndAriaDescribedByTrueBooleanValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" aria-describedby="inputfile-help">
+            HTML,
+            InputFile::tag()
+                ->attributes(['aria-describedby' => true])
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAttributesAndAriaDescribedByTrueStringValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" aria-describedby="inputfile-help">
+            HTML,
+            InputFile::tag()
+                ->attributes(['aria-describedby' => 'true'])
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" name="inputfile" type="file" autofocus>
+            HTML,
+            InputFile::tag()
+                ->autofocus(true)
+                ->id('inputfile')
+                ->name('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'autofocus' attribute.",
+        );
+    }
+
+    public function testRenderWithCapture(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" name="inputfile" type="file" capture="user">
+            HTML,
+            InputFile::tag()
+                ->capture('user')
+                ->id('inputfile')
+                ->name('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'capture' attribute.",
+        );
+    }
+
+    public function testRenderWithCaptureUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" name="inputfile" type="file" capture="environment">
+            HTML,
+            InputFile::tag()
+                ->capture(Capture::ENVIRONMENT)
+                ->id('inputfile')
+                ->name('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'capture' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="file-input" id="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->class('file-input')
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" data-week="value">
+            HTML,
+            InputFile::tag()
+                ->dataAttributes(['week' => 'value'])
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputfile" type="file">
+            HTML,
+            InputFile::tag(['class' => 'default-class'])
+                ->id('inputfile')
+                ->render(),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputfile" name="inputfile" type="file" title="default-title">
+            HTML,
+            InputFile::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->id('inputfile')
+                ->name('inputfile')
+                ->render(),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->render(),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" dir="ltr">
+            HTML,
+            InputFile::tag()
+                ->dir('ltr')
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" dir="ltr">
+            HTML,
+            InputFile::tag()
+                ->dir(Direction::LTR)
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithDisabled(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" disabled>
+            HTML,
+            InputFile::tag()
+                ->disabled(true)
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'disabled' attribute.",
+        );
+    }
+
+    public function testRenderWithForm(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" name="inputfile" type="file" form="form-id">
+            HTML,
+            InputFile::tag()
+                ->form('form-id')
+                ->id('inputfile')
+                ->name('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'form' attribute.",
+        );
+    }
+
+    public function testRenderWithGenerateId(): void
+    {
+        /** @phpstan-var string $id */
+        $id = InputFile::tag()->getAttribute('id', '');
+
+        self::assertMatchesRegularExpression(
+            '/^inputfile-\w+$/',
+            $id,
+            'Failed asserting that element generates an ID when not provided.',
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(
+            InputFile::class,
+            ['class' => 'default-class'],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputfile" name="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->name('inputfile')
+                ->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(InputFile::class, []);
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" hidden>
+            HTML,
+            InputFile::tag()
+                ->hidden(true)
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="file-input" type="file">
+            HTML,
+            InputFile::tag()
+                ->id('file-input')
+                ->render(),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" lang="en">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->lang('en')
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" lang="en">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->lang(Language::ENGLISH)
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithMultiple(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" name="inputfile[]" type="file" multiple>
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->multiple(true)
+                ->name('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'multiple' attribute.",
+        );
+    }
+
+    public function testRenderWithMultipleAndUnchecked(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input name="inputfile[]" type="hidden" value="0">
+            <input id="inputfile" name="inputfile[]" type="file" multiple>
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->multiple(true)
+                ->name('inputfile')
+                ->uncheckedValue('0')
+                ->render(),
+            "Failed asserting that element renders correctly with 'multiple' attribute and unchecked value.",
+        );
+    }
+
+    public function testRenderWithName(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" name="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->name('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'name' attribute.",
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->addAriaAttribute('label', 'Close')
+                ->id('inputfile')
+                ->removeAriaAttribute('label')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->setAttribute('data-test', 'value')
+                ->id('inputfile')
+                ->removeAttribute('data-test')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->addDataAttribute('value', 'test')
+                ->id('inputfile')
+                ->removeDataAttribute('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRequired(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" name="inputfile" type="file" required>
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->name('inputfile')
+                ->required(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'required' attribute.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" role="textbox">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->role('textbox')
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" role="textbox">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->role(Role::TEXTBOX)
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithSetAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" data-test="value">
+            HTML,
+            InputFile::tag()
+                ->setAttribute('data-test', 'value')
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithSetAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" title="Select week">
+            HTML,
+            InputFile::tag()
+                ->setAttribute(GlobalAttribute::TITLE, 'Select week')
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" name="inputfile" type="file" tabindex="1">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->name('inputfile')
+                ->tabIndex(1)
+                ->render(),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="text-muted" id="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->addThemeProvider('muted', DefaultThemeProvider::class)
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" title="Select a week">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->title('Select a week')
+                ->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input type="file">
+            HTML,
+            (string) InputFile::tag()->id(null),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" translate="no">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->translate(false)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" translate="no">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->translate(Translate::NO)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(
+            InputFile::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="file">
+            HTML,
+            InputFile::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            InputFile::class,
+            [],
+        );
+    }
+
+    public function testRenderWithValueIsRemoved(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" name="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->setAttribute('value', 'something')
+                ->id('inputfile')
+                ->name('inputfile')
+                ->render(),
+            "Failed asserting that 'value' attribute is removed.",
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAttribute(): void
+    {
+        $inputFile = InputFile::tag();
+
+        self::assertNotSame(
+            $inputFile,
+            $inputFile->capture(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $inputFile,
+            $inputFile->uncheckedValue(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+}

--- a/tests/Form/InputFileTest.php
+++ b/tests/Form/InputFileTest.php
@@ -54,21 +54,6 @@ final class InputFileTest extends TestCase
         );
     }
 
-    public function testRenderWithAcceptUsingEnum(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <input id="inputfile" name="inputfile" type="file" accept=".jpg, .png">
-            HTML,
-            InputFile::tag()
-                ->accept('.jpg, .png')
-                ->id('inputfile')
-                ->name('inputfile')
-                ->render(),
-            "Failed asserting that element renders correctly with 'accept' attribute.",
-        );
-    }
-
     public function testRenderWithAccesskey(): void
     {
         self::assertSame(
@@ -236,6 +221,20 @@ final class InputFileTest extends TestCase
                 ->id('inputfile')
                 ->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" onclick="alert(&apos;Clicked!&apos;)">
+            HTML,
+            InputFile::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addEvent()' method.",
         );
     }
 
@@ -484,6 +483,25 @@ final class InputFileTest extends TestCase
         );
     }
 
+    public function testRenderWithEvents(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file" onfocus="handleFocus()" onblur="handleBlur()">
+            HTML,
+            InputFile::tag()
+                ->events(
+                    [
+                        'focus' => 'handleFocus()',
+                        'blur' => 'handleBlur()',
+                    ],
+                )
+                ->id('inputfile')
+                ->render(),
+            "Failed asserting that element renders correctly with 'events()' method.",
+        );
+    }
+
     public function testRenderWithForm(): void
     {
         self::assertSame(
@@ -678,6 +696,21 @@ final class InputFileTest extends TestCase
         );
     }
 
+    public function testRenderWithRemoveEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->id('inputfile')
+                ->removeEvent('click')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeEvent()' method.",
+        );
+    }
+
     public function testRenderWithRequired(): void
     {
         self::assertSame(
@@ -828,6 +861,22 @@ final class InputFileTest extends TestCase
                 ->translate(Translate::NO)
                 ->render(),
             "Failed asserting that element renders correctly with 'translate' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithUncheckedValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input name="inputfile" type="hidden" value="0">
+            <input id="inputfile" name="inputfile" type="file">
+            HTML,
+            InputFile::tag()
+                ->id('inputfile')
+                ->name('inputfile')
+                ->uncheckedValue('0')
+                ->render(),
+            'Failed asserting that element renders correctly with unchecked value.',
         );
     }
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
