### PR TITLE
feat(form): Add `InputEmail` class for HTML `<input type="email">` element with attributes and rendering capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Bug #45: Better naming for `CanBeUnchecked` to `HasUnchecked` and update PHPDoc `BaseChoice` classes (@terabytesoftw)
 - Enh #46: Add `InputFile` class for HTML `<input type="file">` element with attributes and rendering capabilities (@terabytesoftw)
 - Bug #47: Update PHPDoc in `tests`and add new tests for `on*` attribute (@terabytesoftw)
+- Enh #48: Add `InputEmail` class for HTML `<input type="email">` element with attributes and rendering capabilities (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Form/InputEmail.php
+++ b/src/Form/InputEmail.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form;
+
+use UIAwesome\Html\Attribute\Form\{
+    CanBeMultiple,
+    CanBeReadonly,
+    CanBeRequired,
+    HasAutocomplete,
+    HasForm,
+    HasList,
+    HasMaxlength,
+    HasMinlength,
+    HasPattern,
+    HasPlaceholder,
+    HasSize,
+};
+use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasSpellcheck, HasTabindex};
+use UIAwesome\Html\Attribute\HasValue;
+use UIAwesome\Html\Attribute\Values\Type;
+use UIAwesome\Html\Core\Element\BaseInput;
+use UIAwesome\Html\Interop\{VoidInterface, Voids};
+
+/**
+ * Renders the HTML `<input type="email">` element.
+ *
+ * Email inputs let the user enter and edit an email address or, if the `multiple` attribute is specified, a list of
+ * email addresses.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Form\InputEmail::tag()
+ *     ->maxlength(255)
+ *     ->name('email')
+ *     ->placeholder('hello@example.com')
+ *     ->required(true)
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/email
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class InputEmail extends BaseInput
+{
+    use CanBeAutofocus;
+    use CanBeMultiple;
+    use CanBeReadonly;
+    use CanBeRequired;
+    use HasAutocomplete;
+    use HasForm;
+    use HasList;
+    use HasMaxlength;
+    use HasMinlength;
+    use HasPattern;
+    use HasPlaceholder;
+    use HasSize;
+    use HasSpellcheck;
+    use HasTabindex;
+    use HasValue;
+
+    /**
+     * Returns the tag enumeration for the `<input>` element.
+     *
+     * @return VoidInterface Tag enumeration instance for `<input>`.
+     */
+    protected function getTag(): VoidInterface
+    {
+        return Voids::INPUT;
+    }
+
+    /**
+     * Returns the default configuration for the input element.
+     *
+     * @return array Default configuration array with method calls as keys.
+     *
+     * @phpstan-return array<string, mixed>
+     */
+    protected function loadDefault(): array
+    {
+        return parent::loadDefault() + ['type' => [Type::EMAIL]];
+    }
+
+    /**
+     * Renders the `<input>` element with its attributes.
+     *
+     * @return string Rendered HTML for the `<input>` element.
+     */
+    protected function run(): string
+    {
+        return $this->buildElement();
+    }
+}

--- a/tests/Form/InputEmailTest.php
+++ b/tests/Form/InputEmailTest.php
@@ -1,0 +1,992 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Form;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{Aria, Autocomplete, Data, Direction, GlobalAttribute, Language, Role, Translate};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Form\InputEmail;
+use UIAwesome\Html\Interop\Inline;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for the {@see InputEmail} class.
+ *
+ * Test coverage.
+ * - Applies global and custom attributes, including `aria-*`, `data-*`, `on*` and enum-backed values.
+ * - Applies input email specific attributes (`autocomplete`, `autofocus`, `disabled`, `form`, `list`, `maxlength`,
+ *   `minlength`, `multiple`, `name`, `pattern`, `placeholder`, `readonly`, `required`, `size`, `spellcheck`,
+ *   `tabindex`, `value`) and renders expected output.
+ * - Renders attributes and string casting for a void element.
+ * - Resolves default and theme providers, including global defaults and user overrides.
+ *
+ * {@see InputEmail} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('form')]
+final class InputEmailTest extends TestCase
+{
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'default',
+            InputEmail::tag()->getAttribute('data-test', 'default'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" accesskey="k">
+            HTML,
+            InputEmail::tag()
+                ->accesskey('k')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" aria-label="Email selector">
+            HTML,
+            InputEmail::tag()
+                ->addAriaAttribute('label', 'Email selector')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" aria-hidden="true">
+            HTML,
+            InputEmail::tag()
+                ->addAriaAttribute(Aria::HIDDEN, true)
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" aria-describedby="custom-help">
+            HTML,
+            InputEmail::tag()
+                ->addAriaAttribute('describedby', 'custom-help')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that an explicit 'aria-describedby' string value is preserved.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" aria-describedby="inputemail-help">
+            HTML,
+            InputEmail::tag()
+                ->addAriaAttribute('describedby', true)
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValueAndIdNull(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input type="email">
+            HTML,
+            InputEmail::tag()
+                ->addAriaAttribute('describedby', true)
+                ->id(null)
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true' and 'id'"
+            . " is 'null'.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValueAndPrefixSuffix(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <span>Prefix</span>
+            <input id="inputemail" type="email" aria-describedby="inputemail-help">
+            <span>Suffix</span>
+            HTML,
+            InputEmail::tag()
+                ->addAriaAttribute('describedby', true)
+                ->id('inputemail')
+                ->prefix('Prefix')
+                ->prefixTag(Inline::SPAN)
+                ->suffix('Suffix')
+                ->suffixTag(Inline::SPAN)
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true' and "
+            . 'prefix/suffix.',
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValueString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" aria-describedby="inputemail-help">
+            HTML,
+            InputEmail::tag()
+                ->addAriaAttribute('describedby', 'true')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueStringValueAndPrefixSuffix(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <span>Prefix</span>
+            <input id="inputemail" type="email" aria-describedby="inputemail-help">
+            <span>Suffix</span>
+            HTML,
+            InputEmail::tag()
+                ->addAriaAttribute('describedby', 'true')
+                ->id('inputemail')
+                ->prefix('Prefix')
+                ->prefixTag(Inline::SPAN)
+                ->suffix('Suffix')
+                ->suffixTag(Inline::SPAN)
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true' and "
+            . 'prefix/suffix.',
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" data-email="value">
+            HTML,
+            InputEmail::tag()
+                ->addDataAttribute('email', 'value')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" data-value="test">
+            HTML,
+            InputEmail::tag()
+                ->addDataAttribute(Data::VALUE, 'test')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithAddEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" onclick="alert(&apos;Clicked!&apos;)">
+            HTML,
+            InputEmail::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addEvent()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" aria-controls="email-picker" aria-label="Select an email">
+            HTML,
+            InputEmail::tag()
+                ->attributes(
+                    [
+                        'aria-controls' => 'email-picker',
+                        'aria-label' => 'Select an email',
+                    ],
+                )
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributesAndAriaDescribedByTrueBooleanValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" aria-describedby="inputemail-help">
+            HTML,
+            InputEmail::tag()
+                ->ariaAttributes(['describedby' => true])
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAriaAttributesAndAriaDescribedByTrueStringValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" aria-describedby="inputemail-help">
+            HTML,
+            InputEmail::tag()
+                ->ariaAttributes(['describedby' => 'true'])
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="email-input" id="inputemail" type="email">
+            HTML,
+            InputEmail::tag()
+                ->attributes(['class' => 'email-input'])
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributesAndAriaDescribedByTrueBooleanValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" aria-describedby="inputemail-help">
+            HTML,
+            InputEmail::tag()
+                ->attributes(['aria-describedby' => true])
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAttributesAndAriaDescribedByTrueStringValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" aria-describedby="inputemail-help">
+            HTML,
+            InputEmail::tag()
+                ->attributes(['aria-describedby' => 'true'])
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAutocomplete(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" autocomplete="on">
+            HTML,
+            InputEmail::tag()
+                ->autocomplete('on')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'autocomplete' attribute.",
+        );
+    }
+
+    public function testRenderWithAutocompleteUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" autocomplete="on">
+            HTML,
+            InputEmail::tag()
+                ->autocomplete(Autocomplete::ON)
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'autocomplete' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" autofocus>
+            HTML,
+            InputEmail::tag()
+                ->autofocus(true)
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'autofocus' attribute.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="email-input" id="inputemail" type="email">
+            HTML,
+            InputEmail::tag()
+                ->class('email-input')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" data-email="value">
+            HTML,
+            InputEmail::tag()
+                ->dataAttributes(['email' => 'value'])
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputemail" type="email">
+            HTML,
+            InputEmail::tag(['class' => 'default-class'])
+                ->id('inputemail')
+                ->render(),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputemail" type="email" title="default-title">
+            HTML,
+            InputEmail::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->id('inputemail')
+                ->render(),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->render(),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" dir="ltr">
+            HTML,
+            InputEmail::tag()
+                ->dir('ltr')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" dir="ltr">
+            HTML,
+            InputEmail::tag()
+                ->dir(Direction::LTR)
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithDisabled(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" disabled>
+            HTML,
+            InputEmail::tag()
+                ->disabled(true)
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'disabled' attribute.",
+        );
+    }
+
+    public function testRenderWithEvents(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" onfocus="handleFocus()" onblur="handleBlur()">
+            HTML,
+            InputEmail::tag()
+                ->events(
+                    [
+                        'focus' => 'handleFocus()',
+                        'blur' => 'handleBlur()',
+                    ],
+                )
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'events()' method.",
+        );
+    }
+
+    public function testRenderWithForm(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" form="form-id">
+            HTML,
+            InputEmail::tag()
+                ->form('form-id')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'form' attribute.",
+        );
+    }
+
+    public function testRenderWithGenerateId(): void
+    {
+        /** @phpstan-var string $id */
+        $id = InputEmail::tag()->getAttribute('id', '');
+
+        self::assertMatchesRegularExpression(
+            '/^inputemail-\w+$/',
+            $id,
+            'Failed asserting that element generates an ID when not provided.',
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(
+            InputEmail::class,
+            ['class' => 'default-class'],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputemail" type="email">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            InputEmail::class,
+            [],
+        );
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" hidden>
+            HTML,
+            InputEmail::tag()
+                ->hidden(true)
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="email-input" type="email">
+            HTML,
+            InputEmail::tag()
+                ->id('email-input')
+                ->render(),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" lang="en">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->lang('en')
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" lang="en">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->lang(Language::ENGLISH)
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithList(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" list="emails">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->list('emails')
+                ->render(),
+            "Failed asserting that element renders correctly with 'list' attribute.",
+        );
+    }
+
+    public function testRenderWithMaxlength(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" maxlength="255">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->maxlength(255)
+                ->render(),
+            "Failed asserting that element renders correctly with 'maxlength' attribute.",
+        );
+    }
+
+    public function testRenderWithMinlength(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" minlength="5">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->minlength(5)
+                ->render(),
+            "Failed asserting that element renders correctly with 'minlength' attribute.",
+        );
+    }
+
+    public function testRenderWithMultiple(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" multiple>
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->multiple(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'multiple' attribute.",
+        );
+    }
+
+    public function testRenderWithName(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" name="email" type="email">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->name('email')
+                ->render(),
+            "Failed asserting that element renders correctly with 'name' attribute.",
+        );
+    }
+
+    public function testRenderWithPattern(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" pattern=".+@example\.com">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->pattern('.+@example\\.com')
+                ->render(),
+            "Failed asserting that element renders correctly with 'pattern' attribute.",
+        );
+    }
+
+    public function testRenderWithPlaceholder(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" placeholder="hello@example.com">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->placeholder('hello@example.com')
+                ->render(),
+            "Failed asserting that element renders correctly with 'placeholder' attribute.",
+        );
+    }
+
+    public function testRenderWithReadonly(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" readonly>
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->readonly(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'readonly' attribute.",
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email">
+            HTML,
+            InputEmail::tag()
+                ->addAriaAttribute('label', 'Close')
+                ->id('inputemail')
+                ->removeAriaAttribute('label')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email">
+            HTML,
+            InputEmail::tag()
+                ->setAttribute('data-test', 'value')
+                ->id('inputemail')
+                ->removeAttribute('data-test')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email">
+            HTML,
+            InputEmail::tag()
+                ->addDataAttribute('value', 'test')
+                ->id('inputemail')
+                ->removeDataAttribute('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email">
+            HTML,
+            InputEmail::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->id('inputemail')
+                ->removeEvent('click')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeEvent()' method.",
+        );
+    }
+
+    public function testRenderWithRequired(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" required>
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->required(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'required' attribute.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" role="textbox">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->role('textbox')
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" role="textbox">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->role(Role::TEXTBOX)
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithSetAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" data-test="value">
+            HTML,
+            InputEmail::tag()
+                ->setAttribute('data-test', 'value')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithSetAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" title="Select email">
+            HTML,
+            InputEmail::tag()
+                ->setAttribute(GlobalAttribute::TITLE, 'Select email')
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method using enum.",
+        );
+    }
+
+    public function testRenderWithSize(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" size="30">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->size(30)
+                ->render(),
+            "Failed asserting that element renders correctly with 'size' attribute.",
+        );
+    }
+
+    public function testRenderWithSpellcheck(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" spellcheck="true">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->spellcheck(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'spellcheck' attribute.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" style='width: 200px;'>
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->style('width: 200px;')
+                ->render(),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" tabindex="1">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->tabIndex(1)
+                ->render(),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="text-muted" id="inputemail" type="email">
+            HTML,
+            InputEmail::tag()
+                ->addThemeProvider('muted', DefaultThemeProvider::class)
+                ->id('inputemail')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" title="Select an email">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->title('Select an email')
+                ->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input type="email">
+            HTML,
+            (string) InputEmail::tag()->id(null),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" translate="no">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->translate(false)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" translate="no">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->translate(Translate::NO)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(
+            InputEmail::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="id-user" type="email">
+            HTML,
+            InputEmail::tag(['id' => 'id-user'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            InputEmail::class,
+            [],
+        );
+    }
+
+    public function testRenderWithValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputemail" type="email" value="hello@example.com">
+            HTML,
+            InputEmail::tag()
+                ->id('inputemail')
+                ->value('hello@example.com')
+                ->render(),
+            "Failed asserting that element renders correctly with 'value' attribute.",
+        );
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
