### PR TITLE
feat(form): Add `InputColor` class for HTML `<input type="color">` element with attributes and rendering capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Enh #49: Add `InputDateTimeLocal` class for HTML `<input type="datetime-local">` element with attributes and rendering capabilities (@terabytesoftw)
 - Bug #50: Standardize `tests` for clarity and consistency across all test cases (@terabytesoftw)
 - Enh #51: Add `InputDate` class for HTML `<input type="date">` element with attributes and rendering capabilities (@terabytesoftw)
+- Enh #52: Add `InputColor` class for HTML `<input type="color">` element with attributes and rendering capabilities (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Form/Attribute/HasAlpha.php
+++ b/src/Form/Attribute/HasAlpha.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+/**
+ * Provides an immutable API for the HTML `alpha` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/color#alpha
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasAlpha
+{
+    /**
+     * Sets the `alpha` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\InputColor::tag()->alpha(true)->render();
+     * ```
+     *
+     * @param bool $value Whether to allow the user to manipulate the color's alpha channel.
+     *
+     * @return static New instance with the updated `alpha` attribute.
+     */
+    public function alpha(bool $value): static
+    {
+        return $this->setAttribute('alpha', $value);
+    }
+}

--- a/src/Form/Attribute/HasColorspace.php
+++ b/src/Form/Attribute/HasColorspace.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Form\Values\Colorspace;
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the HTML `colorspace` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/color#colorspace
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasColorspace
+{
+    /**
+     * Sets the `colorspace` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\InputColor::tag()
+     *     ->colorspace(\UIAwesome\Html\Form\Values\Colorspace::DISPLAY_P3)
+     *     ->render();
+     * ```
+     *
+     * @param string|UnitEnum|null $value Color space (`limited-srgb` or `display-p3`), or `null` to remove the
+     * attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `colorspace` attribute.
+     *
+     * {@see Colorspace} for predefined enum values.
+     */
+    public function colorspace(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, Colorspace::cases(), 'colorspace');
+
+        return $this->setAttribute('colorspace', $value);
+    }
+}

--- a/src/Form/InputColor.php
+++ b/src/Form/InputColor.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form;
+
+use UIAwesome\Html\Attribute\Form\{HasAutocomplete, HasForm, HasList};
+use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
+use UIAwesome\Html\Attribute\HasValue;
+use UIAwesome\Html\Attribute\Values\Type;
+use UIAwesome\Html\Core\Element\BaseInput;
+use UIAwesome\Html\Form\Attribute\{HasAlpha, HasColorspace};
+use UIAwesome\Html\Interop\{VoidInterface, Voids};
+
+/**
+ * Renders the HTML `<input type="color">` element.
+ *
+ * The value must be a valid CSS `<color>` value; defaults to `#000000` if omitted or invalid.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Form\InputColor::tag()
+ *     ->name('head')
+ *     ->render();
+ * echo InputColor::tag()
+ *     ->list('colorsuggestion')
+ *     ->name('head')
+ *     ->value('#ff0000')
+ *     ->render();
+ * echo InputColor::tag()
+ *     ->alpha(true)
+ *     ->colorspace(\UIAwesome\Html\Form\Values\Colorspace::DISPLAY_P3)
+ *     ->name('head')
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/color
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class InputColor extends BaseInput
+{
+    use CanBeAutofocus;
+    use HasAlpha;
+    use HasAutocomplete;
+    use HasColorspace;
+    use HasForm;
+    use HasList;
+    use HasTabindex;
+    use HasValue;
+
+    /**
+     * Returns the tag enumeration for the `<input>` element.
+     *
+     * @return VoidInterface Tag enumeration instance for `<input>`.
+     */
+    protected function getTag(): VoidInterface
+    {
+        return Voids::INPUT;
+    }
+
+    /**
+     * Returns the default configuration for the input element.
+     *
+     * @return array Default configuration array with method calls as keys.
+     *
+     * @phpstan-return array<string, mixed>
+     */
+    protected function loadDefault(): array
+    {
+        return parent::loadDefault() + ['type' => [Type::COLOR]];
+    }
+
+    /**
+     * Renders the `<input>` element with its attributes.
+     *
+     * @return string Rendered HTML for the `<input>` element.
+     */
+    protected function run(): string
+    {
+        return $this->buildElement();
+    }
+}

--- a/src/Form/Values/Colorspace.php
+++ b/src/Form/Values/Colorspace.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Values;
+
+/**
+ * Represents the values for the HTML `colorspace` attribute.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/color#colorspace
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Colorspace: string
+{
+    /**
+     * Represents the `display-p3` token.
+     */
+    case DISPLAY_P3 = 'display-p3';
+
+    /**
+     * Represents the `limited-srgb` token.
+     */
+    case LIMITED_SRGB = 'limited-srgb';
+}

--- a/tests/Form/InputColorTest.php
+++ b/tests/Form/InputColorTest.php
@@ -1,0 +1,983 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Form;
+
+use InvalidArgumentException;
+use PHPForge\Support\Stub\BackedString;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{
+    Aria,
+    Autocomplete,
+    Data,
+    Direction,
+    GlobalAttribute,
+    Language,
+    Role,
+    Translate,
+    Type,
+};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Form\InputColor;
+use UIAwesome\Html\Form\Values\Colorspace;
+use UIAwesome\Html\Helper\Enum;
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Interop\Inline;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see InputColor} class.
+ *
+ * Test coverage.
+ * - Applies global and custom attributes, including `aria-*`, `data-*`, `on*` and enum-backed values.
+ * - Applies input color specific attributes (`alpha`, `autocomplete`, `autofocus`, `colorspace`, `disabled`, `form`,
+ *   `list`, `name`, `tabindex`, `value`) and renders expected output.
+ * - Renders attributes and string casting for a void element.
+ * - Resolves default and theme providers, including global defaults and user overrides.
+ *
+ * {@see InputColor} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('form')]
+final class InputColorTest extends TestCase
+{
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'value',
+            InputColor::tag()->getAttribute('class', 'value'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testGetAttributesReturnsAssignedAttributes(): void
+    {
+        self::assertSame(
+            [
+                'id' => null,
+                'type' => Type::COLOR,
+                'class' => 'value',
+            ],
+            InputColor::tag()
+                ->id(null)
+                ->setAttribute('class', 'value')
+                ->getAttributes(),
+            "Failed asserting that 'getAttributes()' returns the assigned attributes.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" accesskey="value">
+            HTML,
+            InputColor::tag()
+                ->accesskey('value')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" aria-label="value">
+            HTML,
+            InputColor::tag()
+                ->addAriaAttribute('label', 'value')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" aria-label="value">
+            HTML,
+            InputColor::tag()
+                ->addAriaAttribute(Aria::LABEL, 'value')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" aria-describedby="value">
+            HTML,
+            InputColor::tag()
+                ->addAriaAttribute('describedby', 'value')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that an explicit 'aria-describedby' string value is preserved.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" aria-describedby="inputcolor-help">
+            HTML,
+            InputColor::tag()
+                ->addAriaAttribute('describedby', true)
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to "
+            . "'true'.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValueAndIdNull(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input type="color">
+            HTML,
+            InputColor::tag()
+                ->addAriaAttribute('describedby', true)
+                ->id(null)
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true' and 'id'"
+            . " is 'null'.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValueAndPrefixSuffix(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <span>Prefix</span>
+            <input id="inputcolor" type="color" aria-describedby="inputcolor-help">
+            <span>Suffix</span>
+            HTML,
+            InputColor::tag()
+                ->addAriaAttribute('describedby', true)
+                ->id('inputcolor')
+                ->prefix('Prefix')
+                ->prefixTag(Inline::SPAN)
+                ->suffix('Suffix')
+                ->suffixTag(Inline::SPAN)
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true' and "
+            . 'prefix/suffix.',
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueBooleanValueString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" aria-describedby="inputcolor-help">
+            HTML,
+            InputColor::tag()
+                ->addAriaAttribute('describedby', 'true')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAddAriaDescribedByTrueStringValueAndPrefixSuffix(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <span>Prefix</span>
+            <input id="inputcolor" type="color" aria-describedby="inputcolor-help">
+            <span>Suffix</span>
+            HTML,
+            InputColor::tag()
+                ->addAriaAttribute('describedby', 'true')
+                ->id('inputcolor')
+                ->prefix('Prefix')
+                ->prefixTag(Inline::SPAN)
+                ->suffix('Suffix')
+                ->suffixTag(Inline::SPAN)
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true' and "
+            . 'prefix/suffix.',
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" data-value="value">
+            HTML,
+            InputColor::tag()
+                ->addDataAttribute('value', 'value')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" data-value="value">
+            HTML,
+            InputColor::tag()
+                ->addDataAttribute(Data::VALUE, 'value')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" onclick="alert(&apos;Clicked!&apos;)">
+            HTML,
+            InputColor::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addEvent()' method.",
+        );
+    }
+
+    public function testRenderWithAlpha(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" alpha>
+            HTML,
+            InputColor::tag()
+                ->alpha(true)
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'alpha' attribute.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" aria-controls="value" aria-label="value">
+            HTML,
+            InputColor::tag()
+                ->ariaAttributes(
+                    [
+                        'controls' => 'value',
+                        'label' => 'value',
+                    ],
+                )
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributesAndAriaDescribedByTrueBooleanValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" aria-describedby="inputcolor-help">
+            HTML,
+            InputColor::tag()
+                ->ariaAttributes(['describedby' => true])
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAriaAttributesAndAriaDescribedByTrueStringValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" aria-describedby="inputcolor-help">
+            HTML,
+            InputColor::tag()
+                ->ariaAttributes(['describedby' => 'true'])
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="value" id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->attributes(['class' => 'value'])
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributesAndAriaDescribedByTrueBooleanValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" aria-describedby="inputcolor-help">
+            HTML,
+            InputColor::tag()
+                ->attributes(['aria-describedby' => true])
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAttributesAndAriaDescribedByTrueStringValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" aria-describedby="inputcolor-help">
+            HTML,
+            InputColor::tag()
+                ->attributes(['aria-describedby' => 'true'])
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'aria-describedby' attribute set to 'true'.",
+        );
+    }
+
+    public function testRenderWithAutocomplete(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" autocomplete="on">
+            HTML,
+            InputColor::tag()
+                ->autocomplete('on')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'autocomplete' attribute.",
+        );
+    }
+
+    public function testRenderWithAutocompleteUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" autocomplete="on">
+            HTML,
+            InputColor::tag()
+                ->autocomplete(Autocomplete::ON)
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'autocomplete' attribute.",
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" autofocus>
+            HTML,
+            InputColor::tag()
+                ->autofocus(true)
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'autofocus' attribute.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="value" id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->class('value')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithClassUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="value" id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->class(BackedString::VALUE)
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithColorspace(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" colorspace="display-p3">
+            HTML,
+            InputColor::tag()
+                ->colorspace('display-p3')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'colorspace' attribute.",
+        );
+    }
+
+    public function testRenderWithColorspaceUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" colorspace="display-p3">
+            HTML,
+            InputColor::tag()
+                ->colorspace(Colorspace::DISPLAY_P3)
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'colorspace' attribute.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" data-value="value">
+            HTML,
+            InputColor::tag()
+                ->dataAttributes(['value' => 'value'])
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputcolor" type="color">
+            HTML,
+            InputColor::tag(['class' => 'default-class'])
+                ->id('inputcolor')
+                ->render(),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputcolor" type="color" title="default-title">
+            HTML,
+            InputColor::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->id('inputcolor')
+                ->render(),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->render(),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" dir="ltr">
+            HTML,
+            InputColor::tag()
+                ->dir('ltr')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" dir="ltr">
+            HTML,
+            InputColor::tag()
+                ->dir(Direction::LTR)
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDisabled(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" disabled>
+            HTML,
+            InputColor::tag()
+                ->disabled(true)
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'disabled' attribute.",
+        );
+    }
+
+    public function testRenderWithEvents(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" onfocus="handleFocus()" onblur="handleBlur()">
+            HTML,
+            InputColor::tag()
+                ->events(
+                    [
+                        'focus' => 'handleFocus()',
+                        'blur' => 'handleBlur()',
+                    ],
+                )
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'events()' method.",
+        );
+    }
+
+    public function testRenderWithForm(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" form="value">
+            HTML,
+            InputColor::tag()
+                ->form('value')
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'form' attribute.",
+        );
+    }
+
+    public function testRenderWithGenerateId(): void
+    {
+        /** @phpstan-var string $id */
+        $id = InputColor::tag()->getAttribute('id', '');
+
+        self::assertMatchesRegularExpression(
+            '/^inputcolor-\w+$/',
+            $id,
+            'Failed asserting that element generates an ID when not provided.',
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(
+            InputColor::class,
+            ['class' => 'default-class'],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <input class="default-class" id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            InputColor::class,
+            [],
+        );
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" hidden>
+            HTML,
+            InputColor::tag()
+                ->hidden(true)
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" lang="en">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->lang('en')
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" lang="en">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->lang(Language::ENGLISH)
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithList(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" list="value">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->list('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'list' attribute.",
+        );
+    }
+
+    public function testRenderWithName(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" name="value" type="color">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->name('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'name' attribute.",
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->addAriaAttribute('label', 'value')
+                ->id('inputcolor')
+                ->removeAriaAttribute('label')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->setAttribute('class', 'value')
+                ->id('inputcolor')
+                ->removeAttribute('class')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->addDataAttribute('value', 'value')
+                ->id('inputcolor')
+                ->removeDataAttribute('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->id('inputcolor')
+                ->removeEvent('click')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeEvent()' method.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" role="textbox">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->role('textbox')
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" role="textbox">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->role(Role::TEXTBOX)
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithSetAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="value" id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->setAttribute('class', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithSetAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" title="value">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->setAttribute(GlobalAttribute::TITLE, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" style='value'>
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->style('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" tabindex="1">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->tabIndex(1)
+                ->render(),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithTemplate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="value">
+            <input id="inputcolor" type="color">
+            </div>
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->template('<div class="value">' . PHP_EOL . '{tag}' . PHP_EOL . '</div>')
+                ->render(),
+            'Failed asserting that element renders correctly with a custom template wrapper.',
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="text-muted" id="inputcolor" type="color">
+            HTML,
+            InputColor::tag()
+                ->addThemeProvider('muted', DefaultThemeProvider::class)
+                ->id('inputcolor')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" title="value">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->title('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input type="color">
+            HTML,
+            (string) InputColor::tag()->id(null),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" translate="no">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->translate(false)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" translate="no">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->translate(Translate::NO)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(
+            InputColor::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <input class="from-global" id="value" type="color">
+            HTML,
+            InputColor::tag(['id' => 'value'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            InputColor::class,
+            [],
+        );
+    }
+
+    public function testRenderWithValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="inputcolor" type="color" value="#ff0000">
+            HTML,
+            InputColor::tag()
+                ->id('inputcolor')
+                ->value('#ff0000')
+                ->render(),
+            "Failed asserting that element renders correctly with 'value' attribute.",
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingColorspace(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                'colorspace',
+                implode("', '", Enum::normalizeArray(Colorspace::cases())),
+            ),
+        );
+
+        InputColor::tag()->colorspace('invalid-value');
+    }
+}

--- a/tests/Form/InputColorTest.php
+++ b/tests/Form/InputColorTest.php
@@ -967,6 +967,22 @@ final class InputColorTest extends TestCase
         );
     }
 
+    public function testReturnNewInstanceWhenSettingAttribute(): void
+    {
+        $inputColor = InputColor::tag();
+
+        self::assertNotSame(
+            $inputColor,
+            $inputColor->alpha(false),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $inputColor,
+            $inputColor->colorspace(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
     public function testThrowInvalidArgumentExceptionForSettingColorspace(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
