### PR TITLE
feat(form): Add `TextArea` class for HTML `<textarea>` element with attributes and rendering capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Bug #50: Standardize `tests` for clarity and consistency across all test cases (@terabytesoftw)
 - Enh #51: Add `InputDate` class for HTML `<input type="date">` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #52: Add `InputColor` class for HTML `<input type="color">` element with attributes and rendering capabilities (@terabytesoftw)
+- Enh #53: Add `TextArea` class for HTML `<textarea>` element with attributes and rendering capabilities (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Form/Attribute/HasCols.php
+++ b/src/Form/Attribute/HasCols.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Exception\Message;
+use UIAwesome\Html\Helper\Validator;
+
+/**
+ * Provides an immutable API for the HTML `cols` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/textarea#cols
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasCols
+{
+    /**
+     * Sets the `cols` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\TextArea::tag()
+     *     ->cols(20)
+     *     ->render();
+     * ```
+     *
+     * @param int|string|null $value Visible width in average character widths (positive integer), or `null` to remove
+     * the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not a positive integer.
+     *
+     * @return static New instance with the updated `cols` attribute.
+     */
+    public function cols(int|string|null $value): static
+    {
+        if ($value !== null && Validator::intLike($value, 1) === false) {
+            throw new InvalidArgumentException(
+                Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                    (string) $value,
+                    'cols',
+                    'value > 0',
+                ),
+            );
+        }
+
+        return $this->setAttribute('cols', $value);
+    }
+}

--- a/src/Form/Attribute/HasRows.php
+++ b/src/Form/Attribute/HasRows.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Exception\Message;
+use UIAwesome\Html\Helper\Validator;
+
+/**
+ * Provides an immutable API for the HTML `rows` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/textarea#rows
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasRows
+{
+    /**
+     * Sets the `rows` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\TextArea::tag()
+     *     ->rows(5)
+     *     ->render();
+     * ```
+     *
+     * @param int|string|null $value Number of visible text lines (positive integer), or `null` to remove the
+     * attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not a positive integer.
+     *
+     * @return static New instance with the updated `rows` attribute.
+     */
+    public function rows(int|string|null $value): static
+    {
+        if ($value !== null && Validator::intLike($value, 1) === false) {
+            throw new InvalidArgumentException(
+                Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                    (string) $value,
+                    'rows',
+                    'value > 0',
+                ),
+            );
+        }
+
+        return $this->setAttribute('rows', $value);
+    }
+}

--- a/src/Form/Attribute/HasWrap.php
+++ b/src/Form/Attribute/HasWrap.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Form\Values\Wrap;
+use UIAwesome\Html\Helper\Validator;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the HTML `wrap` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/textarea#wrap
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasWrap
+{
+    /**
+     * Sets the `wrap` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\TextArea::tag()
+     *     ->wrap('hard')
+     *     ->render();
+     * echo \UIAwesome\Html\Form\TextArea::tag()
+     *     ->wrap(\UIAwesome\Html\Form\Values\Wrap::SOFT)
+     *     ->render();
+     * ```
+     *
+     * @param string|UnitEnum|null $value Line-wrapping behavior (`hard`, `soft`, or `off`), or `null` to remove the
+     * attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `wrap` attribute.
+     *
+     * {@see Wrap} for predefined enum values.
+     */
+    public function wrap(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, Wrap::cases(), 'wrap');
+
+        return $this->setAttribute('wrap', $value);
+    }
+}

--- a/src/Form/TextArea.php
+++ b/src/Form/TextArea.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form;
+
+use UIAwesome\Html\Attribute\{CanBeDisabled, HasName};
+use UIAwesome\Html\Attribute\Form\{
+    CanBeReadonly,
+    CanBeRequired,
+    HasAutocomplete,
+    HasDirname,
+    HasForm,
+    HasMaxlength,
+    HasMinlength,
+    HasPlaceholder,
+};
+use UIAwesome\Html\Attribute\Global\{HasAutocapitalize, HasAutocorrect};
+use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Form\Attribute\{HasCols, HasRows, HasWrap};
+use UIAwesome\Html\Interop\{Block, BlockInterface};
+
+/**
+ * Renders the HTML `<textarea>` element for multiline plain-text input.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Form\TextArea::tag()
+ *     ->name('comment')
+ *     ->rows(5)
+ *     ->cols(33)
+ *     ->placeholder('Enter your comment here')
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/textarea
+ * {@see BaseBlock} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TextArea extends BaseBlock
+{
+    use CanBeDisabled;
+    use CanBeReadonly;
+    use CanBeRequired;
+    use HasAutocapitalize;
+    use HasAutocomplete;
+    use HasAutocorrect;
+    use HasCols;
+    use HasDirname;
+    use HasForm;
+    use HasMaxlength;
+    use HasMinlength;
+    use HasName;
+    use HasPlaceholder;
+    use HasRows;
+    use HasWrap;
+
+    /**
+     * Returns the tag enumeration for the `<textarea>` element.
+     *
+     * @return BlockInterface Tag enumeration instance for `<textarea>`.
+     *
+     * {@see Block} for valid block-level tags.
+     */
+    protected function getTag(): BlockInterface
+    {
+        return Block::TEXT_AREA;
+    }
+}

--- a/src/Form/Values/Wrap.php
+++ b/src/Form/Values/Wrap.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Values;
+
+/**
+ * Represents values for the HTML `wrap` attribute.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/textarea#wrap
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum Wrap: string
+{
+    /**
+     * Represents the `hard` token. The browser automatically inserts line breaks (CR+LF) so no line exceeds the
+     * width of the control. The `cols` attribute must be specified.
+     */
+    case HARD = 'hard';
+
+    /**
+     * Represents the `off` token. Like `soft`, but changes appearance to `white-space: pre` so line segments
+     * exceeding `cols` are not wrapped. Non-standard.
+     */
+    case OFF = 'off';
+
+    /**
+     * Represents the `soft` token. The browser ensures all line breaks in the value are CR+LF pairs, but no
+     * additional line breaks are added. This is the default.
+     */
+    case SOFT = 'soft';
+}

--- a/tests/Form/TextAreaTest.php
+++ b/tests/Form/TextAreaTest.php
@@ -1,0 +1,1050 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Form;
+
+use InvalidArgumentException;
+use PHPForge\Support\Stub\BackedString;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Exception\Message;
+use UIAwesome\Html\Attribute\Values\{
+    Aria,
+    Autocomplete,
+    ContentEditable,
+    Data,
+    Direction,
+    Draggable,
+    GlobalAttribute,
+    Language,
+    Role,
+    Translate,
+};
+use UIAwesome\Html\Attribute\Values\{Autocapitalize, Autocorrect};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Form\TextArea;
+use UIAwesome\Html\Form\Values\Wrap;
+use UIAwesome\Html\Helper\Enum;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see TextArea} rendering and attribute behavior.
+ *
+ * Test coverage.
+ * - Applies global and custom attributes, including `aria-*`, `data-*`, `on*` and enum-backed values.
+ * - Ensures attribute accessors return assigned values and fallback defaults.
+ * - Renders content, raw HTML, and string casting with expected encoding behavior.
+ * - Resolves default and theme providers, including global defaults and user overrides.
+ * - Covers all `<textarea>` element-specific attributes per MDN specification.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('form')]
+final class TextAreaTest extends TestCase
+{
+    public function testContentEncodesValues(): void
+    {
+        self::assertSame(
+            '&lt;value&gt;',
+            TextArea::tag()
+                ->content('<value>')
+                ->getContent(),
+            "Failed asserting that 'content()' method encodes values correctly.",
+        );
+    }
+
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'value',
+            TextArea::tag()->getAttribute('class', 'value'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testGetAttributesReturnsAssignedAttributes(): void
+    {
+        self::assertSame(
+            ['class' => 'value'],
+            TextArea::tag()
+                ->setAttribute('class', 'value')
+                ->getAttributes(),
+            "Failed asserting that 'getAttributes()' returns the assigned attributes.",
+        );
+    }
+
+    public function testHtmlDoesNotEncodeValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea>
+            <value>
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->html('<value>')
+                ->render(),
+            "Failed asserting that element renders correctly with 'html()' method.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea accesskey="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->accesskey('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea aria-label="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->addAriaAttribute('label', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea aria-label="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->addAriaAttribute(Aria::LABEL, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea data-value="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->addDataAttribute('value', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea data-value="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->addDataAttribute(Data::VALUE, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea aria-controls="value" aria-label="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->ariaAttributes(
+                    [
+                        'controls' => 'value',
+                        'label' => 'value',
+                    ],
+                )
+                ->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea class="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->attributes(['class' => 'value'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAutocapitalize(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea autocapitalize="sentences">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->autocapitalize('sentences')
+                ->render(),
+            "Failed asserting that element renders correctly with 'autocapitalize' attribute.",
+        );
+    }
+
+    public function testRenderWithAutocapitalizeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea autocapitalize="sentences">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->autocapitalize(Autocapitalize::SENTENCES)
+                ->render(),
+            "Failed asserting that element renders correctly with 'autocapitalize' attribute.",
+        );
+    }
+
+    public function testRenderWithAutocomplete(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea autocomplete="on">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->autocomplete('on')
+                ->render(),
+            "Failed asserting that element renders correctly with 'autocomplete' attribute.",
+        );
+    }
+
+    public function testRenderWithAutocompleteUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea autocomplete="on">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->autocomplete(Autocomplete::ON)
+                ->render(),
+            "Failed asserting that element renders correctly with 'autocomplete' attribute.",
+        );
+    }
+
+    public function testRenderWithAutocorrect(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea autocorrect="on">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->autocorrect('on')
+                ->render(),
+            "Failed asserting that element renders correctly with 'autocorrect' attribute.",
+        );
+    }
+
+    public function testRenderWithAutocorrectUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea autocorrect="on">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->autocorrect(Autocorrect::ON)
+                ->render(),
+            "Failed asserting that element renders correctly with 'autocorrect' attribute.",
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea autofocus>
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->autofocus(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'autofocus' attribute.",
+        );
+    }
+
+    public function testRenderWithBeginEnd(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea>
+            Content
+            </textarea>
+            HTML,
+            TextArea::tag()->begin() . 'Content' . TextArea::end(),
+            "Failed asserting that element renders correctly with 'begin()' and 'end()' methods.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea class="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->class('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithClassUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea class="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->class(BackedString::VALUE)
+                ->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithCols(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea cols="20">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->cols(20)
+                ->render(),
+            "Failed asserting that element renders correctly with 'cols' attribute.",
+        );
+    }
+
+    public function testRenderWithContent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea>
+            value
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->content('value')
+                ->render(),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithContentEditable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea contenteditable="true">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->contentEditable(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute.",
+        );
+    }
+
+    public function testRenderWithContentEditableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea contenteditable="true">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->contentEditable(ContentEditable::TRUE)
+                ->render(),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea data-value="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->dataAttributes(['value' => 'value'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea class="default-class">
+            </textarea>
+            HTML,
+            TextArea::tag(['class' => 'default-class'])->render(),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea class="default-class" title="default-title">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->render(),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea dir="ltr">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->dir('ltr')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirname(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea dirname="comment.dir">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->dirname('comment.dir')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dirname' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea dir="ltr">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->dir(Direction::LTR)
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDisabled(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea disabled>
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->disabled(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'disabled' attribute.",
+        );
+    }
+
+    public function testRenderWithDraggable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea draggable="true">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->draggable(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'draggable' attribute.",
+        );
+    }
+
+    public function testRenderWithDraggableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea draggable="true">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->draggable(Draggable::TRUE)
+                ->render(),
+            "Failed asserting that element renders correctly with 'draggable' attribute.",
+        );
+    }
+
+    public function testRenderWithForm(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea form="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->form('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'form' attribute.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(
+            TextArea::class,
+            ['class' => 'default-class'],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <textarea class="default-class">
+            </textarea>
+            HTML,
+            TextArea::tag()->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            TextArea::class,
+            [],
+        );
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea hidden>
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->hidden(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea id="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->id('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea lang="en">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->lang('en')
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea lang="en">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->lang(Language::ENGLISH)
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithMaxlength(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea maxlength="100">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->maxlength(100)
+                ->render(),
+            "Failed asserting that element renders correctly with 'maxlength' attribute.",
+        );
+    }
+
+    public function testRenderWithMicroData(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea itemid="https://example.com/item" itemprop="name" itemref="info" itemscope itemtype="https://schema.org/Thing">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->itemId('https://example.com/item')
+                ->itemProp('name')
+                ->itemRef('info')
+                ->itemScope(true)
+                ->itemType('https://schema.org/Thing')
+                ->render(),
+            'Failed asserting that element renders correctly with microdata attributes.',
+        );
+    }
+
+    public function testRenderWithMinlength(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea minlength="10">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->minlength(10)
+                ->render(),
+            "Failed asserting that element renders correctly with 'minlength' attribute.",
+        );
+    }
+
+    public function testRenderWithName(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea name="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->name('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'name' attribute.",
+        );
+    }
+
+    public function testRenderWithPlaceholder(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea placeholder="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->placeholder('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'placeholder' attribute.",
+        );
+    }
+
+    public function testRenderWithReadonly(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea readonly>
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->readonly(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'readonly' attribute.",
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea>
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->addAriaAttribute('label', 'value')
+                ->removeAriaAttribute('label')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea>
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->setAttribute('class', 'value')
+                ->removeAttribute('class')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea>
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->addDataAttribute('value', 'value')
+                ->removeDataAttribute('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRequired(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea required>
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->required(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'required' attribute.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea role="textbox">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->role('textbox')
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea role="textbox">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->role(Role::TEXTBOX)
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRows(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea rows="5">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->rows(5)
+                ->render(),
+            "Failed asserting that element renders correctly with 'rows' attribute.",
+        );
+    }
+
+    public function testRenderWithSetAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea class="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->setAttribute('class', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithSetAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea title="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->setAttribute(GlobalAttribute::TITLE, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithSpellcheck(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea spellcheck="true">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->spellcheck(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'spellcheck' attribute.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea style='value'>
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->style('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea tabindex="3">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->tabIndex(3)
+                ->render(),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea class="text-muted">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->addThemeProvider('muted', DefaultThemeProvider::class)
+                ->render(),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea title="value">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->title('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea>
+            </textarea>
+            HTML,
+            (string) TextArea::tag(),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea translate="no">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->translate(false)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea translate="no">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->translate(Translate::NO)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(
+            TextArea::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <textarea class="from-global" id="value">
+            </textarea>
+            HTML,
+            TextArea::tag(['id' => 'value'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            TextArea::class,
+            [],
+        );
+    }
+
+    public function testRenderWithWrap(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea wrap="hard">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->wrap('hard')
+                ->render(),
+            "Failed asserting that element renders correctly with 'wrap' attribute.",
+        );
+    }
+
+    public function testRenderWithWrapUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <textarea wrap="hard">
+            </textarea>
+            HTML,
+            TextArea::tag()
+                ->wrap(Wrap::HARD)
+                ->render(),
+            "Failed asserting that element renders correctly with 'wrap' attribute.",
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAttribute(): void
+    {
+        $textArea = TextArea::tag();
+
+        self::assertNotSame(
+            $textArea,
+            $textArea->cols(1),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $textArea,
+            $textArea->rows(1),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $textArea,
+            $textArea->wrap(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingCols(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                '0',
+                'cols',
+                'value > 0',
+            ),
+        );
+
+        TextArea::tag()->cols(0);
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingRows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                '0',
+                'rows',
+                'value > 0',
+            ),
+        );
+
+        TextArea::tag()->rows(0);
+    }
+
+    public function testThrowInvalidArgumentExceptionForSettingWrap(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            \UIAwesome\Html\Helper\Exception\Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                'wrap',
+                implode("', '", Enum::normalizeArray(Wrap::cases())),
+            ),
+        );
+
+        TextArea::tag()->wrap('invalid-value');
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
