### PR TITLE
feat(form): Add `Button` class for HTML `<button>` element with attributes and rendering capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Enh #53: Add `TextArea` class for HTML `<textarea>` element with attributes and rendering capabilities (@terabytesoftw)
 - Bug #54: Update exception test method names for consistency and clarity (@terabytesoftw)
 - Bug #55: Remove `BaseChoice` class and related mixins; update `InputCheckbox`, `InputFile`, and `InputRadio` to extend `BaseInput` class (@terabytesoftw)
+- Enh #56: Add `Button` class for HTML `<button>` element with attributes and rendering capabilities (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Form/Attribute/HasCommand.php
+++ b/src/Form/Attribute/HasCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+use Stringable;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the HTML `command` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#command
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasCommand
+{
+    /**
+     * Sets the `command` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\Button::tag()
+     *     ->command('show-modal')
+     *     ->render();
+     * echo \UIAwesome\Html\Form\Button::tag()
+     *     ->command(\UIAwesome\Html\Form\Values\ButtonCommand::SHOW_MODAL)
+     *     ->render();
+     * ```
+     *
+     * @param string|Stringable|UnitEnum|null $value Command value, or `null` to remove the attribute. Accepts
+     * predefined values (`show-modal`, `close`, `request-close`, `show-popover`, `hide-popover`, `toggle-popover`) or
+     * any custom value prefixed with `--`.
+     *
+     * @return static New instance with the updated `command` attribute.
+     *
+     * {@see \UIAwesome\Html\Form\Values\ButtonCommand} for predefined enum values.
+     */
+    public function command(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->setAttribute('command', $value);
+    }
+}

--- a/src/Form/Attribute/HasCommandfor.php
+++ b/src/Form/Attribute/HasCommandfor.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Attribute;
+
+use Stringable;
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the HTML `commandfor` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#commandfor
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasCommandfor
+{
+    /**
+     * Sets the `commandfor` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\Button::tag()
+     *     ->commandfor('my-dialog')
+     *     ->render();
+     * ```
+     *
+     * @param string|Stringable|UnitEnum|null $value ID of the element to control, or `null` to remove the attribute.
+     *
+     * @return static New instance with the updated `commandfor` attribute.
+     */
+    public function commandfor(string|Stringable|UnitEnum|null $value): static
+    {
+        return $this->setAttribute('commandfor', $value);
+    }
+}

--- a/src/Form/Button.php
+++ b/src/Form/Button.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\{CanBeDisabled, HasName, HasValue};
+use UIAwesome\Html\Attribute\Element\{HasPopoverTarget, HasPopoverTargetAction};
+use UIAwesome\Html\Attribute\Form\HasForm;
+use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
+use UIAwesome\Html\Core\Element\BaseInline;
+use UIAwesome\Html\Form\Attribute\{
+    HasCommand,
+    HasCommandfor,
+    HasFormaction,
+    HasFormenctype,
+    HasFormmethod,
+    HasFormnovalidate,
+    HasFormtarget,
+};
+use UIAwesome\Html\Form\Values\ButtonType;
+use UIAwesome\Html\Helper\Validator;
+use UIAwesome\Html\Interop\{Inline, InlineInterface};
+use UnitEnum;
+
+/**
+ * Renders the HTML `<button>` element.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Form\Button::tag()
+ *     ->class('btn btn-primary')
+ *     ->content('Submit')
+ *     ->type(\UIAwesome\Html\Form\Values\ButtonType::SUBMIT)
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button
+ * {@see BaseInline} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class Button extends BaseInline
+{
+    use CanBeAutofocus;
+    use CanBeDisabled;
+    use HasCommand;
+    use HasCommandfor;
+    use HasForm;
+    use HasFormaction;
+    use HasFormenctype;
+    use HasFormmethod;
+    use HasFormnovalidate;
+    use HasFormtarget;
+    use HasName;
+    use HasPopoverTarget;
+    use HasPopoverTargetAction;
+    use HasTabindex;
+    use HasValue;
+
+    /**
+     * Sets the `type` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Form\Button::tag()
+     *     ->type('submit')
+     *     ->render();
+     * echo \UIAwesome\Html\Form\Button::tag()
+     *     ->type(\UIAwesome\Html\Form\Values\ButtonType::SUBMIT)
+     *     ->render();
+     * ```
+     *
+     * @param string|UnitEnum|null $value Button type (`button`, `reset`, `submit`), or `null` to remove the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not valid.
+     *
+     * @return static New instance with the updated `type` attribute.
+     *
+     * {@see ButtonType} for predefined enum values.
+     */
+    public function type(string|UnitEnum|null $value): static
+    {
+        Validator::oneOf($value, ButtonType::cases(), 'type');
+
+        return $this->setAttribute('type', $value);
+    }
+
+    /**
+     * Returns the tag enumeration for the `<button>` element.
+     *
+     * @return InlineInterface Tag enumeration instance for `<button>`.
+     *
+     * {@see Inline} for valid inline-level tags.
+     */
+    protected function getTag(): InlineInterface
+    {
+        return Inline::BUTTON;
+    }
+
+    /**
+     * Renders the `<button>` element with its content and attributes.
+     *
+     * @return string Rendered HTML for the `<button>` element.
+     */
+    protected function run(): string
+    {
+        return $this->buildElement($this->getContent());
+    }
+}

--- a/src/Form/Values/ButtonCommand.php
+++ b/src/Form/Values/ButtonCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Values;
+
+/**
+ * Represents values for the HTML `command` attribute of the `<button>` element.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#command
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum ButtonCommand: string
+{
+    /**
+     * Represents the `close` token. Closes the targeted `<dialog>` element.
+     */
+    case CLOSE = 'close';
+
+    /**
+     * Represents the `hide-popover` token. Hides a showing popover element.
+     */
+    case HIDE_POPOVER = 'hide-popover';
+
+    /**
+     * Represents the `request-close` token. Triggers a `cancel` event on the targeted `<dialog>`, allowing
+     * `preventDefault()` to block closing.
+     */
+    case REQUEST_CLOSE = 'request-close';
+
+    /**
+     * Represents the `show-modal` token. Shows the targeted `<dialog>` element as a modal.
+     */
+    case SHOW_MODAL = 'show-modal';
+
+    /**
+     * Represents the `show-popover` token. Shows a hidden popover element.
+     */
+    case SHOW_POPOVER = 'show-popover';
+
+    /**
+     * Represents the `toggle-popover` token. Toggles the visibility of the targeted popover element.
+     */
+    case TOGGLE_POPOVER = 'toggle-popover';
+}

--- a/src/Form/Values/ButtonType.php
+++ b/src/Form/Values/ButtonType.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Values;
+
+/**
+ * Represents values for the HTML `type` attribute of the `<button>` element.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#type
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+enum ButtonType: string
+{
+    /**
+     * Represents the `button` token. The button has no default behavior, and does nothing when pressed by default.
+     */
+    case BUTTON = 'button';
+
+    /**
+     * Represents the `reset` token. The button resets all the controls to their initial values.
+     */
+    case RESET = 'reset';
+
+    /**
+     * Represents the `submit` token. The button submits the form data to the server. This is the default if the
+     * attribute is not specified for buttons associated with a `<form>`.
+     */
+    case SUBMIT = 'submit';
+}

--- a/tests/Form/ButtonTest.php
+++ b/tests/Form/ButtonTest.php
@@ -1,0 +1,835 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Form;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{
+    Aria,
+    Data,
+    Direction,
+    GlobalAttribute,
+    Language,
+    PopoverTargetAction,
+    Role,
+    Target,
+    Translate,
+};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Form\Button;
+use UIAwesome\Html\Form\Values\{ButtonCommand, ButtonType};
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see Button} inline form behavior.
+ *
+ * Test coverage.
+ * - Applies button specific attributes (`autofocus`, `command`, `commandfor`, `disabled`, `form`, `formaction`,
+ *   `formenctype`, `formmethod`, `formnovalidate`, `formtarget`, `name`, `popovertarget`, `popovertargetaction`,
+ *   `tabindex`, `type`, `value`) and renders expected output.
+ * - Applies global and custom attributes, including `aria-*`, `data-*`, `on*` and enum-backed values.
+ * - Ensures attribute accessors return assigned values and fallback defaults.
+ * - Renders content, raw HTML, and string casting with expected encoding behavior.
+ * - Resolves default and theme providers, including global defaults and user overrides.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('form')]
+final class ButtonTest extends TestCase
+{
+    public function testContentEncodesValues(): void
+    {
+        self::assertSame(
+            '&lt;value&gt;',
+            Button::tag()
+                ->content('<value>')
+                ->getContent(),
+            "Failed asserting that 'content()' method encodes values correctly.",
+        );
+    }
+
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'value',
+            Button::tag()->getAttribute('class', 'value'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testGetAttributesReturnsAssignedAttributes(): void
+    {
+        self::assertSame(
+            ['class' => 'value'],
+            Button::tag()
+                ->setAttribute('class', 'value')
+                ->getAttributes(),
+            "Failed asserting that 'getAttributes()' returns the assigned attributes.",
+        );
+    }
+
+    public function testHtmlDoesNotEncodeValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button><value></button>
+            HTML,
+            Button::tag()
+                ->html('<value>')
+                ->render(),
+            "Failed asserting that element renders correctly with 'html()' method.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button accesskey="value"></button>
+            HTML,
+            Button::tag()
+                ->accesskey('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button aria-label="value"></button>
+            HTML,
+            Button::tag()
+                ->addAriaAttribute('label', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button aria-label="value"></button>
+            HTML,
+            Button::tag()
+                ->addAriaAttribute(Aria::LABEL, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button data-value="value"></button>
+            HTML,
+            Button::tag()
+                ->addDataAttribute('value', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button data-value="value"></button>
+            HTML,
+            Button::tag()
+                ->addDataAttribute(Data::VALUE, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button aria-controls="value" aria-label="value"></button>
+            HTML,
+            Button::tag()
+                ->ariaAttributes(
+                    [
+                        'controls' => 'value',
+                        'label' => 'value',
+                    ],
+                )
+                ->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button class="value"></button>
+            HTML,
+            Button::tag()
+                ->attributes(['class' => 'value'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button autofocus></button>
+            HTML,
+            Button::tag()
+                ->autofocus(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'autofocus' attribute.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button class="value"></button>
+            HTML,
+            Button::tag()
+                ->class('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithCommand(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button command="show-modal"></button>
+            HTML,
+            Button::tag()
+                ->command('show-modal')
+                ->render(),
+            "Failed asserting that element renders correctly with 'command' attribute.",
+        );
+    }
+
+    public function testRenderWithCommandfor(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button commandfor="my-dialog"></button>
+            HTML,
+            Button::tag()
+                ->commandfor('my-dialog')
+                ->render(),
+            "Failed asserting that element renders correctly with 'commandfor' attribute.",
+        );
+    }
+
+    public function testRenderWithCommandUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button command="show-modal"></button>
+            HTML,
+            Button::tag()
+                ->command(ButtonCommand::SHOW_MODAL)
+                ->render(),
+            "Failed asserting that element renders correctly with 'command' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithContent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button>&lt;value&gt;</button>
+            HTML,
+            Button::tag()
+                ->content('<value>')
+                ->render(),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button data-value="value"></button>
+            HTML,
+            Button::tag()
+                ->dataAttributes(['value' => 'value'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button class="default-class"></button>
+            HTML,
+            Button::tag(['class' => 'default-class'])->render(),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button class="default-class" title="default-title"></button>
+            HTML,
+            Button::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->render(),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button></button>
+            HTML,
+            Button::tag()->render(),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button dir="ltr"></button>
+            HTML,
+            Button::tag()
+                ->dir('ltr')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button dir="ltr"></button>
+            HTML,
+            Button::tag()
+                ->dir(Direction::LTR)
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDisabled(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button disabled></button>
+            HTML,
+            Button::tag()
+                ->disabled(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'disabled' attribute.",
+        );
+    }
+
+    public function testRenderWithForm(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button form="value"></button>
+            HTML,
+            Button::tag()
+                ->form('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'form' attribute.",
+        );
+    }
+
+    public function testRenderWithFormaction(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button formaction="/submit-handler"></button>
+            HTML,
+            Button::tag()
+                ->formaction('/submit-handler')
+                ->render(),
+            "Failed asserting that element renders correctly with 'formaction' attribute.",
+        );
+    }
+
+    public function testRenderWithFormenctype(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button formenctype="multipart/form-data"></button>
+            HTML,
+            Button::tag()
+                ->formenctype('multipart/form-data')
+                ->render(),
+            "Failed asserting that element renders correctly with 'formenctype' attribute.",
+        );
+    }
+
+    public function testRenderWithFormmethod(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button formmethod="post"></button>
+            HTML,
+            Button::tag()
+                ->formmethod('post')
+                ->render(),
+            "Failed asserting that element renders correctly with 'formmethod' attribute.",
+        );
+    }
+
+    public function testRenderWithFormnovalidate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button formnovalidate></button>
+            HTML,
+            Button::tag()
+                ->formnovalidate(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'formnovalidate' attribute.",
+        );
+    }
+
+    public function testRenderWithFormnovalidateValueFalse(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button></button>
+            HTML,
+            Button::tag()
+                ->formnovalidate(false)
+                ->render(),
+            "Failed asserting that element renders correctly with 'formnovalidate' set to 'false'.",
+        );
+    }
+
+    public function testRenderWithFormnovalidateValueNull(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button></button>
+            HTML,
+            Button::tag()
+                ->formnovalidate(null)
+                ->render(),
+            "Failed asserting that element renders correctly with 'formnovalidate' set to 'null'.",
+        );
+    }
+
+    public function testRenderWithFormtarget(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button formtarget="_blank"></button>
+            HTML,
+            Button::tag()
+                ->formtarget('_blank')
+                ->render(),
+            "Failed asserting that element renders correctly with 'formtarget' attribute.",
+        );
+    }
+
+    public function testRenderWithFormtargetUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button formtarget="_blank"></button>
+            HTML,
+            Button::tag()
+                ->formtarget(Target::BLANK)
+                ->render(),
+            "Failed asserting that element renders correctly with 'formtarget' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(
+            Button::class,
+            ['class' => 'default-class'],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <button class="default-class"></button>
+            HTML,
+            Button::tag()->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            Button::class,
+            [],
+        );
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button hidden></button>
+            HTML,
+            Button::tag()
+                ->hidden(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button id="value"></button>
+            HTML,
+            Button::tag()
+                ->id('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button lang="en"></button>
+            HTML,
+            Button::tag()
+                ->lang('en')
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button lang="en"></button>
+            HTML,
+            Button::tag()
+                ->lang(Language::ENGLISH)
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithName(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button name="value"></button>
+            HTML,
+            Button::tag()
+                ->name('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'name' attribute.",
+        );
+    }
+
+    public function testRenderWithPopoverTarget(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button popovertarget="my-popover"></button>
+            HTML,
+            Button::tag()
+                ->popoverTarget('my-popover')
+                ->render(),
+            "Failed asserting that element renders correctly with 'popovertarget' attribute.",
+        );
+    }
+
+    public function testRenderWithPopoverTargetAction(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button popovertargetaction="toggle"></button>
+            HTML,
+            Button::tag()
+                ->popoverTargetAction('toggle')
+                ->render(),
+            "Failed asserting that element renders correctly with 'popovertargetaction' attribute.",
+        );
+    }
+
+    public function testRenderWithPopoverTargetActionUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button popovertargetaction="toggle"></button>
+            HTML,
+            Button::tag()
+                ->popoverTargetAction(PopoverTargetAction::TOGGLE)
+                ->render(),
+            "Failed asserting that element renders correctly with 'popovertargetaction' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button></button>
+            HTML,
+            Button::tag()
+                ->addAriaAttribute('label', 'value')
+                ->removeAriaAttribute('label')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button></button>
+            HTML,
+            Button::tag()
+                ->setAttribute('class', 'value')
+                ->removeAttribute('class')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button></button>
+            HTML,
+            Button::tag()
+                ->addDataAttribute('value', 'value')
+                ->removeDataAttribute('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button role="button"></button>
+            HTML,
+            Button::tag()
+                ->role('button')
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button role="button"></button>
+            HTML,
+            Button::tag()
+                ->role(Role::BUTTON)
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithSetAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button class="value"></button>
+            HTML,
+            Button::tag()
+                ->setAttribute('class', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithSetAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button title="value"></button>
+            HTML,
+            Button::tag()
+                ->setAttribute(GlobalAttribute::TITLE, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button style='value'></button>
+            HTML,
+            Button::tag()
+                ->style('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button tabindex="1"></button>
+            HTML,
+            Button::tag()
+                ->tabIndex(1)
+                ->render(),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button class="text-muted"></button>
+            HTML,
+            Button::tag()
+                ->addThemeProvider('muted', DefaultThemeProvider::class)
+                ->render(),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button title="value"></button>
+            HTML,
+            Button::tag()
+                ->title('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button></button>
+            HTML,
+            (string) Button::tag(),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button translate="no"></button>
+            HTML,
+            Button::tag()
+                ->translate(false)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button translate="no"></button>
+            HTML,
+            Button::tag()
+                ->translate(Translate::NO)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithType(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button type="submit"></button>
+            HTML,
+            Button::tag()
+                ->type('submit')
+                ->render(),
+            "Failed asserting that element renders correctly with 'type' attribute.",
+        );
+    }
+
+    public function testRenderWithTypeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button type="submit"></button>
+            HTML,
+            Button::tag()
+                ->type(ButtonType::SUBMIT)
+                ->render(),
+            "Failed asserting that element renders correctly with 'type' attribute using enum.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(
+            Button::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <button class="from-global" id="value"></button>
+            HTML,
+            Button::tag(['id' => 'value'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            Button::class,
+            [],
+        );
+    }
+
+    public function testRenderWithValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <button value="value"></button>
+            HTML,
+            Button::tag()
+                ->value('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'value' attribute.",
+        );
+    }
+}

--- a/tests/Form/ButtonTest.php
+++ b/tests/Form/ButtonTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Tests\Form;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Attribute\Values\{
@@ -20,6 +21,8 @@ use UIAwesome\Html\Attribute\Values\{
 use UIAwesome\Html\Core\Factory\SimpleFactory;
 use UIAwesome\Html\Form\Button;
 use UIAwesome\Html\Form\Values\{ButtonCommand, ButtonType};
+use UIAwesome\Html\Helper\Enum;
+use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
 
 /**
@@ -241,7 +244,7 @@ final class ButtonTest extends TestCase
             Button::tag()
                 ->command(ButtonCommand::SHOW_MODAL)
                 ->render(),
-            "Failed asserting that element renders correctly with 'command' attribute using enum.",
+            "Failed asserting that element renders correctly with 'command' attribute.",
         );
     }
 
@@ -458,7 +461,7 @@ final class ButtonTest extends TestCase
             Button::tag()
                 ->formtarget(Target::BLANK)
                 ->render(),
-            "Failed asserting that element renders correctly with 'formtarget' attribute using enum.",
+            "Failed asserting that element renders correctly with 'formtarget' attribute.",
         );
     }
 
@@ -583,7 +586,7 @@ final class ButtonTest extends TestCase
             Button::tag()
                 ->popoverTargetAction(PopoverTargetAction::TOGGLE)
                 ->render(),
-            "Failed asserting that element renders correctly with 'popovertargetaction' attribute using enum.",
+            "Failed asserting that element renders correctly with 'popovertargetaction' attribute.",
         );
     }
 
@@ -792,7 +795,7 @@ final class ButtonTest extends TestCase
             Button::tag()
                 ->type(ButtonType::SUBMIT)
                 ->render(),
-            "Failed asserting that element renders correctly with 'type' attribute using enum.",
+            "Failed asserting that element renders correctly with 'type' attribute.",
         );
     }
 
@@ -831,5 +834,19 @@ final class ButtonTest extends TestCase
                 ->render(),
             "Failed asserting that element renders correctly with 'value' attribute.",
         );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                'type',
+                implode("', '", Enum::normalizeArray(ButtonType::cases())),
+            ),
+        );
+
+        Button::tag()->type('invalid-value');
     }
 }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
