### PR TITLE
fix(html): Align tag enums and defaults provider with latest `ui-awesome/html-core` and `ui-awesome/html-interop` changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Enh #56: Add `Button` class for HTML `<button>` element with attributes and rendering capabilities (@terabytesoftw)
 - Bug #57: Add tests for invalid argument exceptions in HTML attributes (@terabytesoftw)
 - Enh #59: Add `Form` class for HTML `<form>` element with attributes and rendering capabilities (@terabytesoftw)
+- Bug #61: Align tag enums and defaults provider with latest `ui-awesome/html-core` and `ui-awesome/html-interop` changes (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "ui-awesome/html-attribute": "^0.6@dev",
         "ui-awesome/html-core": "^0.6@dev",
         "ui-awesome/html-helper": "^0.7",
-        "ui-awesome/html-interop": "^0.3",
-        "ui-awesome/html-mixin": "^0.4"
+        "ui-awesome/html-interop": "^0.4@dev",
+        "ui-awesome/html-mixin": "dev-main as 0.4"
     },
     "require-dev": {
         "infection/infection": "^0.27|^0.32",
@@ -26,7 +26,8 @@
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-strict-rules": "^2.0.3",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^10.5",
+        "ui-awesome/html-contracts": "^0.1@dev"
     },
     "autoload": {
         "psr-4": {

--- a/src/Embedded/Img.php
+++ b/src/Embedded/Img.php
@@ -18,7 +18,7 @@ use UIAwesome\Html\Attribute\Element\{
 use UIAwesome\Html\Attribute\{HasCrossorigin, HasFetchpriority, HasSizes};
 use UIAwesome\Html\Core\Element\BaseVoid;
 use UIAwesome\Html\Embedded\Attribute\{HasElementtiming, HasIsmap};
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<img>` element for embedding images.
@@ -60,11 +60,11 @@ final class Img extends BaseVoid
     /**
      * Returns the tag enumeration for the `<img>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<img>`.
+     * @return Voids Tag enumeration instance for `<img>`.
      *
      * {@see Voids} for valid void-level tags.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::IMG;
     }

--- a/src/Flow/Div.php
+++ b/src/Flow/Div.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Flow;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<div>` element for grouping flow content.
@@ -29,11 +29,11 @@ final class Div extends BaseBlock
     /**
      * Returns the tag enumeration for the `<div>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<div>`.
+     * @return Block Tag enumeration instance for `<div>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::DIV;
     }

--- a/src/Flow/Hr.php
+++ b/src/Flow/Hr.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Flow;
 
 use UIAwesome\Html\Core\Element\BaseVoid;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<hr>` element for thematic breaks.
@@ -28,11 +28,11 @@ final class Hr extends BaseVoid
     /**
      * Returns the tag enumeration for the `<hr>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<hr>`.
+     * @return Voids Tag enumeration instance for `<hr>`.
      *
      * {@see Voids} for valid void-level tags.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::HR;
     }

--- a/src/Flow/Main.php
+++ b/src/Flow/Main.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Flow;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<main>` element for dominant document content.
@@ -29,11 +29,11 @@ final class Main extends BaseBlock
     /**
      * Returns the tag enumeration for the `<main>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<main>`.
+     * @return Block Tag enumeration instance for `<main>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::MAIN;
     }

--- a/src/Flow/P.php
+++ b/src/Flow/P.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Flow;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<p>` element for paragraphs.
@@ -29,11 +29,11 @@ final class P extends BaseBlock
     /**
      * Returns the tag enumeration for the `<p>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<p>`.
+     * @return Block Tag enumeration instance for `<p>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::P;
     }

--- a/src/Form/Button.php
+++ b/src/Form/Button.php
@@ -21,7 +21,7 @@ use UIAwesome\Html\Form\Attribute\{
 };
 use UIAwesome\Html\Form\Values\ButtonType;
 use UIAwesome\Html\Helper\Validator;
-use UIAwesome\Html\Interop\{Inline, InlineInterface};
+use UIAwesome\Html\Interop\Inline;
 use UnitEnum;
 
 /**
@@ -91,11 +91,11 @@ final class Button extends BaseInline
     /**
      * Returns the tag enumeration for the `<button>` element.
      *
-     * @return InlineInterface Tag enumeration instance for `<button>`.
+     * @return Inline Tag enumeration instance for `<button>`.
      *
      * {@see Inline} for valid inline-level tags.
      */
-    protected function getTag(): InlineInterface
+    protected function getTag(): Inline
     {
         return Inline::BUTTON;
     }

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -9,7 +9,7 @@ use UIAwesome\Html\Attribute\Global\HasAutocapitalize;
 use UIAwesome\Html\Attribute\{HasName, HasRel, HasTarget};
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Form\Attribute\{CanBeNovalidate, HasAcceptCharset, HasAction, HasEnctype, HasMethod};
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<form>` element for submitting user data.
@@ -45,11 +45,11 @@ final class Form extends BaseBlock
     /**
      * Returns the tag enumeration for the `<form>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<form>`.
+     * @return Block Tag enumeration instance for `<form>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::FORM;
     }

--- a/src/Form/InputCheckbox.php
+++ b/src/Form/InputCheckbox.php
@@ -10,7 +10,7 @@ use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
 use UIAwesome\Html\Form\Mixin\HasCheckedState;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Represents the HTML `<input type="checkbox">` element.
@@ -55,9 +55,9 @@ final class InputCheckbox extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputColor.php
+++ b/src/Form/InputColor.php
@@ -10,7 +10,7 @@ use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
 use UIAwesome\Html\Form\Attribute\{HasAlpha, HasColorspace};
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="color">` element.
@@ -53,9 +53,9 @@ final class InputColor extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputDate.php
+++ b/src/Form/InputDate.php
@@ -18,7 +18,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="date">` element.
@@ -65,9 +65,9 @@ final class InputDate extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputDateTimeLocal.php
+++ b/src/Form/InputDateTimeLocal.php
@@ -18,7 +18,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="datetime-local">` element.
@@ -65,9 +65,9 @@ final class InputDateTimeLocal extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputEmail.php
+++ b/src/Form/InputEmail.php
@@ -21,7 +21,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasSpellcheck, HasTabindex}
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="email">` element.
@@ -65,9 +65,9 @@ final class InputEmail extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputFile.php
+++ b/src/Form/InputFile.php
@@ -10,7 +10,7 @@ use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
 use UIAwesome\Html\Form\Attribute\HasCapture;
 use UIAwesome\Html\Helper\Naming;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="file">` element.
@@ -71,9 +71,9 @@ final class InputFile extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputHidden.php
+++ b/src/Form/InputHidden.php
@@ -8,7 +8,7 @@ use UIAwesome\Html\Attribute\Form\{HasAutocomplete, HasForm};
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="hidden">` element.
@@ -37,9 +37,9 @@ final class InputHidden extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputImage.php
+++ b/src/Form/InputImage.php
@@ -15,7 +15,7 @@ use UIAwesome\Html\Form\Attribute\{
     HasFormnovalidate,
     HasFormtarget
 };
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="image">` element.
@@ -55,9 +55,9 @@ final class InputImage extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputMonth.php
+++ b/src/Form/InputMonth.php
@@ -18,7 +18,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="month">` element.
@@ -66,9 +66,9 @@ final class InputMonth extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputNumber.php
+++ b/src/Form/InputNumber.php
@@ -19,7 +19,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="number">` element.
@@ -59,9 +59,9 @@ final class InputNumber extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputPassword.php
+++ b/src/Form/InputPassword.php
@@ -19,7 +19,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasInputMode, HasTabindex};
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="password">` element.
@@ -60,9 +60,9 @@ final class InputPassword extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputRadio.php
+++ b/src/Form/InputRadio.php
@@ -10,7 +10,7 @@ use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
 use UIAwesome\Html\Form\Mixin\HasCheckedState;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Represents the HTML `<input type="radio">` element.
@@ -55,9 +55,9 @@ final class InputRadio extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputRange.php
+++ b/src/Form/InputRange.php
@@ -16,7 +16,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="range">` element.
@@ -60,9 +60,9 @@ final class InputRange extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputReset.php
+++ b/src/Form/InputReset.php
@@ -8,7 +8,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="reset">` element.
@@ -36,9 +36,9 @@ final class InputReset extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputSearch.php
+++ b/src/Form/InputSearch.php
@@ -21,7 +21,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasSpellcheck, HasTabindex}
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="search">` element.
@@ -67,9 +67,9 @@ final class InputSearch extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputSubmit.php
+++ b/src/Form/InputSubmit.php
@@ -16,7 +16,7 @@ use UIAwesome\Html\Form\Attribute\{
     HasFormnovalidate,
     HasFormtarget
 };
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="submit">` element.
@@ -49,9 +49,9 @@ final class InputSubmit extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputTel.php
+++ b/src/Form/InputTel.php
@@ -20,7 +20,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasSpellcheck, HasTabindex}
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="tel">` element for telephone number input.
@@ -63,9 +63,9 @@ final class InputTel extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputText.php
+++ b/src/Form/InputText.php
@@ -21,7 +21,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasSpellcheck, HasTabindex}
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="text">` element.
@@ -63,9 +63,9 @@ final class InputText extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputTime.php
+++ b/src/Form/InputTime.php
@@ -18,7 +18,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="time">` element.
@@ -65,9 +65,9 @@ final class InputTime extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputUrl.php
+++ b/src/Form/InputUrl.php
@@ -20,7 +20,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasSpellcheck, HasTabindex}
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="url">` element for URL input.
@@ -63,9 +63,9 @@ final class InputUrl extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/InputWeek.php
+++ b/src/Form/InputWeek.php
@@ -18,7 +18,7 @@ use UIAwesome\Html\Attribute\Global\{CanBeAutofocus, HasTabindex};
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Attribute\Values\Type;
 use UIAwesome\Html\Core\Element\BaseInput;
-use UIAwesome\Html\Interop\{VoidInterface, Voids};
+use UIAwesome\Html\Interop\Voids;
 
 /**
  * Renders the HTML `<input type="week">` element.
@@ -65,9 +65,9 @@ final class InputWeek extends BaseInput
     /**
      * Returns the tag enumeration for the `<input>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<input>`.
+     * @return Voids Tag enumeration instance for `<input>`.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): Voids
     {
         return Voids::INPUT;
     }

--- a/src/Form/TextArea.php
+++ b/src/Form/TextArea.php
@@ -18,7 +18,7 @@ use UIAwesome\Html\Attribute\Form\{
 use UIAwesome\Html\Attribute\Global\{HasAutocapitalize, HasAutocorrect};
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Form\Attribute\{HasCols, HasRows, HasWrap};
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<textarea>` element for multiline plain-text input.
@@ -60,11 +60,11 @@ final class TextArea extends BaseBlock
     /**
      * Returns the tag enumeration for the `<textarea>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<textarea>`.
+     * @return Block Tag enumeration instance for `<textarea>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::TEXT_AREA;
     }

--- a/src/Heading/H1.php
+++ b/src/Heading/H1.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Heading;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<h1>` element for top-level section headings.
@@ -29,11 +29,11 @@ final class H1 extends BaseBlock
     /**
      * Returns the tag enumeration for the `<h1>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<h1>`.
+     * @return Block Tag enumeration instance for `<h1>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::H1;
     }

--- a/src/Heading/H2.php
+++ b/src/Heading/H2.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Heading;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<h2>` element for second-level section headings.
@@ -29,11 +29,11 @@ final class H2 extends BaseBlock
     /**
      * Returns the tag enumeration for the `<h2>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<h2>`.
+     * @return Block Tag enumeration instance for `<h2>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::H2;
     }

--- a/src/Heading/H3.php
+++ b/src/Heading/H3.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Heading;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<h3>` element for third-level section headings.
@@ -29,11 +29,11 @@ final class H3 extends BaseBlock
     /**
      * Returns the tag enumeration for the `<h3>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<h3>`.
+     * @return Block Tag enumeration instance for `<h3>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::H3;
     }

--- a/src/Heading/H4.php
+++ b/src/Heading/H4.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Heading;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<h4>` element for fourth-level section headings.
@@ -29,11 +29,11 @@ final class H4 extends BaseBlock
     /**
      * Returns the tag enumeration for the `<h4>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<h4>`.
+     * @return Block Tag enumeration instance for `<h4>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::H4;
     }

--- a/src/Heading/H5.php
+++ b/src/Heading/H5.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Heading;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<h5>` element for fifth-level section headings.
@@ -29,11 +29,11 @@ final class H5 extends BaseBlock
     /**
      * Returns the tag enumeration for the `<h5>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<h5>`.
+     * @return Block Tag enumeration instance for `<h5>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::H5;
     }

--- a/src/Heading/H6.php
+++ b/src/Heading/H6.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Heading;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<h6>` element for lowest-level section headings.
@@ -29,11 +29,11 @@ final class H6 extends BaseBlock
     /**
      * Returns the tag enumeration for the `<h6>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<h6>`.
+     * @return Block Tag enumeration instance for `<h6>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::H6;
     }

--- a/src/Heading/HGroup.php
+++ b/src/Heading/HGroup.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Heading;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<hgroup>` element for grouped heading content.
@@ -31,11 +31,11 @@ final class HGroup extends BaseBlock
     /**
      * Returns the tag enumeration for the `<hgroup>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<hgroup>`.
+     * @return Block Tag enumeration instance for `<hgroup>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::HGROUP;
     }

--- a/src/List/Dd.php
+++ b/src/List/Dd.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\List;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, Lists};
+use UIAwesome\Html\Interop\Lists;
 
 /**
  * Renders the HTML `<dd>` element for description details.
@@ -28,11 +28,11 @@ final class Dd extends BaseBlock
     /**
      * Returns the tag enumeration for the `<dd>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<dd>`.
+     * @return Lists Tag enumeration instance for `<dd>`.
      *
      * {@see Lists} for valid list-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Lists
     {
         return Lists::DD;
     }

--- a/src/List/Dl.php
+++ b/src/List/Dl.php
@@ -6,7 +6,7 @@ namespace UIAwesome\Html\List;
 
 use Stringable;
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, Lists};
+use UIAwesome\Html\Interop\Lists;
 
 /**
  * Renders the HTML `<dl>` element for description lists.
@@ -73,11 +73,11 @@ final class Dl extends BaseBlock
     /**
      * Returns the tag enumeration for the `<dl>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<dl>`.
+     * @return Lists Tag enumeration instance for `<dl>`.
      *
      * {@see Lists} for valid list-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Lists
     {
         return Lists::DL;
     }

--- a/src/List/Dt.php
+++ b/src/List/Dt.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\List;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, Lists};
+use UIAwesome\Html\Interop\Lists;
 
 /**
  * Renders the HTML `<dt>` element for description terms.
@@ -28,11 +28,11 @@ final class Dt extends BaseBlock
     /**
      * Returns the tag enumeration for the `<dt>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<dt>`.
+     * @return Lists Tag enumeration instance for `<dt>`.
      *
      * {@see Lists} for valid list-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Lists
     {
         return Lists::DT;
     }

--- a/src/List/Li.php
+++ b/src/List/Li.php
@@ -6,7 +6,7 @@ namespace UIAwesome\Html\List;
 
 use UIAwesome\Html\Attribute\HasValue;
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, Lists};
+use UIAwesome\Html\Interop\Lists;
 
 /**
  * Renders the HTML `<li>` element for list items.
@@ -32,11 +32,11 @@ final class Li extends BaseBlock
     /**
      * Returns the tag enumeration for the `<li>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<li>`.
+     * @return Lists Tag enumeration instance for `<li>`.
      *
      * {@see Lists} for valid list-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Lists
     {
         return Lists::LI;
     }

--- a/src/List/Ol.php
+++ b/src/List/Ol.php
@@ -6,7 +6,7 @@ namespace UIAwesome\Html\List;
 
 use Stringable;
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, Lists};
+use UIAwesome\Html\Interop\Lists;
 use UIAwesome\Html\List\Attribute\{HasReversed, HasStart};
 
 /**
@@ -89,11 +89,11 @@ final class Ol extends BaseBlock
     /**
      * Returns the tag enumeration for the `<ol>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<ol>`.
+     * @return Lists Tag enumeration instance for `<ol>`.
      *
      * {@see Lists} for valid list-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Lists
     {
         return Lists::OL;
     }

--- a/src/List/Ul.php
+++ b/src/List/Ul.php
@@ -6,7 +6,7 @@ namespace UIAwesome\Html\List;
 
 use Stringable;
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, Lists};
+use UIAwesome\Html\Interop\Lists;
 
 /**
  * Renders the HTML `<ul>` element for unordered lists.
@@ -83,11 +83,11 @@ final class Ul extends BaseBlock
     /**
      * Returns the tag enumeration for the `<ul>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<ul>`.
+     * @return Lists Tag enumeration instance for `<ul>`.
      *
      * {@see Lists} for valid list-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Lists
     {
         return Lists::UL;
     }

--- a/src/Metadata/Base.php
+++ b/src/Metadata/Base.php
@@ -7,7 +7,7 @@ namespace UIAwesome\Html\Metadata;
 use UIAwesome\Html\Attribute\Element\HasHref;
 use UIAwesome\Html\Attribute\HasTarget;
 use UIAwesome\Html\Core\Element\BaseVoid;
-use UIAwesome\Html\Interop\{MetadataVoid, VoidInterface};
+use UIAwesome\Html\Interop\MetadataVoid;
 
 /**
  * Renders the HTML `<base>` element for the document base URL and default navigation target.
@@ -34,11 +34,11 @@ final class Base extends BaseVoid
     /**
      * Returns the tag enumeration for the `<base>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<base>`.
+     * @return MetadataVoid Tag enumeration instance for `<base>`.
      *
      * {@see MetadataVoid} for valid metadata void tags.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): MetadataVoid
     {
         return MetadataVoid::BASE;
     }

--- a/src/Metadata/Link.php
+++ b/src/Metadata/Link.php
@@ -22,7 +22,7 @@ use UIAwesome\Html\Attribute\{
 };
 use UIAwesome\Html\Attribute\Element\HasHref;
 use UIAwesome\Html\Core\Element\BaseVoid;
-use UIAwesome\Html\Interop\{MetadataVoid, VoidInterface};
+use UIAwesome\Html\Interop\MetadataVoid;
 
 /**
  * Renders the HTML `<link>` element for relationships to external resources.
@@ -62,11 +62,11 @@ final class Link extends BaseVoid
     /**
      * Returns the tag enumeration for the `<link>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<link>`.
+     * @return MetadataVoid Tag enumeration instance for `<link>`.
      *
      * {@see MetadataVoid} for valid metadata void tags.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): MetadataVoid
     {
         return MetadataVoid::LINK;
     }

--- a/src/Metadata/Meta.php
+++ b/src/Metadata/Meta.php
@@ -6,7 +6,7 @@ namespace UIAwesome\Html\Metadata;
 
 use UIAwesome\Html\Attribute\{HasCharset, HasContent, HasHttpEquiv, HasMedia, HasName};
 use UIAwesome\Html\Core\Element\BaseVoid;
-use UIAwesome\Html\Interop\{MetadataVoid, VoidInterface};
+use UIAwesome\Html\Interop\MetadataVoid;
 
 /**
  * Renders the HTML `<meta>` element for document metadata.
@@ -36,11 +36,11 @@ final class Meta extends BaseVoid
     /**
      * Returns the tag enumeration for the `<meta>` element.
      *
-     * @return VoidInterface Tag enumeration instance for `<meta>`.
+     * @return MetadataVoid Tag enumeration instance for `<meta>`.
      *
      * {@see MetadataVoid} for valid metadata void tags.
      */
-    protected function getTag(): VoidInterface
+    protected function getTag(): MetadataVoid
     {
         return MetadataVoid::META;
     }

--- a/src/Metadata/NoScript.php
+++ b/src/Metadata/NoScript.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Metadata;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, MetadataBlock};
+use UIAwesome\Html\Interop\MetadataBlock;
 
 /**
  * Renders the HTML `<noscript>` element for fallback content when scripting is unavailable.
@@ -28,11 +28,11 @@ final class NoScript extends BaseBlock
     /**
      * Returns the tag enumeration for the `<noscript>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<noscript>`.
+     * @return MetadataBlock Tag enumeration instance for `<noscript>`.
      *
      * {@see MetadataBlock} for valid metadata block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): MetadataBlock
     {
         return MetadataBlock::NOSCRIPT;
     }

--- a/src/Metadata/Script.php
+++ b/src/Metadata/Script.php
@@ -14,7 +14,7 @@ use UIAwesome\Html\Attribute\{
     HasType,
 };
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, MetadataBlock};
+use UIAwesome\Html\Interop\MetadataBlock;
 use UIAwesome\Html\Metadata\Attribute\{HasAsync, HasDefer, HasNomodule};
 
 /**
@@ -50,11 +50,11 @@ final class Script extends BaseBlock
     /**
      * Returns the tag enumeration for the `<script>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<script>`.
+     * @return MetadataBlock Tag enumeration instance for `<script>`.
      *
      * {@see MetadataBlock} for valid metadata block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): MetadataBlock
     {
         return MetadataBlock::SCRIPT;
     }

--- a/src/Metadata/Style.php
+++ b/src/Metadata/Style.php
@@ -7,7 +7,7 @@ namespace UIAwesome\Html\Metadata;
 use UIAwesome\Html\Attribute\Global\HasNonce;
 use UIAwesome\Html\Attribute\{HasBlocking, HasMedia, HasType};
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, MetadataBlock};
+use UIAwesome\Html\Interop\MetadataBlock;
 
 /**
  * Renders the HTML `<style>` element for embedded CSS rules.
@@ -35,11 +35,11 @@ final class Style extends BaseBlock
     /**
      * Returns the tag enumeration for the `<style>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<style>`.
+     * @return MetadataBlock Tag enumeration instance for `<style>`.
      *
      * {@see MetadataBlock} for valid metadata block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): MetadataBlock
     {
         return MetadataBlock::STYLE;
     }

--- a/src/Metadata/Template.php
+++ b/src/Metadata/Template.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Metadata;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, MetadataBlock};
+use UIAwesome\Html\Interop\MetadataBlock;
 use UIAwesome\Html\Metadata\Attribute\{
     HasShadowRootClonable,
     HasShadowRootDelegatesFocus,
@@ -41,11 +41,11 @@ final class Template extends BaseBlock
     /**
      * Returns the tag enumeration for the `<template>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<template>`.
+     * @return MetadataBlock Tag enumeration instance for `<template>`.
      *
      * {@see MetadataBlock} for valid metadata block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): MetadataBlock
     {
         return MetadataBlock::TEMPLATE;
     }

--- a/src/Metadata/Title.php
+++ b/src/Metadata/Title.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Metadata;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, MetadataBlock};
+use UIAwesome\Html\Interop\MetadataBlock;
 
 /**
  * Renders the HTML `<title>` element for the document title.
@@ -28,11 +28,11 @@ final class Title extends BaseBlock
     /**
      * Returns the tag enumeration for the `<title>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<title>`.
+     * @return MetadataBlock Tag enumeration instance for `<title>`.
      *
      * {@see MetadataBlock} for valid metadata block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): MetadataBlock
     {
         return MetadataBlock::TITLE;
     }

--- a/src/Palpable/A.php
+++ b/src/Palpable/A.php
@@ -15,7 +15,7 @@ use UIAwesome\Html\Attribute\{
 };
 use UIAwesome\Html\Attribute\Element\HasHref;
 use UIAwesome\Html\Core\Element\BaseInline;
-use UIAwesome\Html\Interop\{Inline, InlineInterface};
+use UIAwesome\Html\Interop\Inline;
 
 /**
  * Renders the HTML `<a>` element for hyperlinks.
@@ -48,11 +48,11 @@ final class A extends BaseInline
     /**
      * Returns the tag enumeration for the `<a>` element.
      *
-     * @return InlineInterface Tag enumeration instance for `<a>`.
+     * @return Inline Tag enumeration instance for `<a>`.
      *
      * {@see Inline} for valid inline-level tags.
      */
-    protected function getTag(): InlineInterface
+    protected function getTag(): Inline
     {
         return Inline::A;
     }

--- a/src/Phrasing/I.php
+++ b/src/Phrasing/I.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Phrasing;
 
 use UIAwesome\Html\Core\Element\BaseInline;
-use UIAwesome\Html\Interop\{Inline, InlineInterface};
+use UIAwesome\Html\Interop\Inline;
 
 /**
  * Renders the HTML `<i>` element for alternate voice or idiomatic text.
@@ -29,11 +29,11 @@ final class I extends BaseInline
     /**
      * Returns the tag enumeration for the `<i>` element.
      *
-     * @return InlineInterface Tag enumeration instance for `<i>`.
+     * @return Inline Tag enumeration instance for `<i>`.
      *
      * {@see Inline} for valid inline-level tags.
      */
-    protected function getTag(): InlineInterface
+    protected function getTag(): Inline
     {
         return Inline::I;
     }

--- a/src/Phrasing/Label.php
+++ b/src/Phrasing/Label.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Phrasing;
 
 use UIAwesome\Html\Core\Element\BaseInline;
-use UIAwesome\Html\Interop\{Inline, InlineInterface};
+use UIAwesome\Html\Interop\Inline;
 
 /**
  * Renders the HTML `<label>` element.
@@ -47,11 +47,11 @@ final class Label extends BaseInline
     /**
      * Returns the tag enumeration for the `<label>` element.
      *
-     * @return InlineInterface Tag enumeration instance for `<label>`.
+     * @return Inline Tag enumeration instance for `<label>`.
      *
      * {@see Inline} for valid inline-level tags.
      */
-    protected function getTag(): InlineInterface
+    protected function getTag(): Inline
     {
         return Inline::LABEL;
     }

--- a/src/Phrasing/Span.php
+++ b/src/Phrasing/Span.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Phrasing;
 
 use UIAwesome\Html\Core\Element\BaseInline;
-use UIAwesome\Html\Interop\{Inline, InlineInterface};
+use UIAwesome\Html\Interop\Inline;
 
 /**
  * Renders the HTML `<span>` element for generic inline content.
@@ -29,11 +29,11 @@ final class Span extends BaseInline
     /**
      * Returns the tag enumeration for the `<span>` element.
      *
-     * @return InlineInterface Tag enumeration instance for `<span>`.
+     * @return Inline Tag enumeration instance for `<span>`.
      *
      * {@see Inline} for valid inline-level tags.
      */
-    protected function getTag(): InlineInterface
+    protected function getTag(): Inline
     {
         return Inline::SPAN;
     }

--- a/src/Root/Body.php
+++ b/src/Root/Body.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Root;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, Root};
+use UIAwesome\Html\Interop\Root;
 
 /**
  * Renders the HTML `<body>` element for document content.
@@ -29,11 +29,11 @@ final class Body extends BaseBlock
     /**
      * Returns the tag enumeration for the `<body>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<body>`.
+     * @return Root Tag enumeration instance for `<body>`.
      *
      * {@see Root} for valid root-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Root
     {
         return Root::BODY;
     }

--- a/src/Root/Footer.php
+++ b/src/Root/Footer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Root;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<footer>` element for section or page footer content.
@@ -29,11 +29,11 @@ final class Footer extends BaseBlock
     /**
      * Returns the tag enumeration for the `<footer>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<footer>`.
+     * @return Block Tag enumeration instance for `<footer>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::FOOTER;
     }

--- a/src/Root/Head.php
+++ b/src/Root/Head.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Root;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, Root};
+use UIAwesome\Html\Interop\Root;
 
 /**
  * Renders the HTML `<head>` element for document metadata.
@@ -28,11 +28,11 @@ final class Head extends BaseBlock
     /**
      * Returns the tag enumeration for the `<head>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<head>`.
+     * @return Root Tag enumeration instance for `<head>`.
      *
      * {@see Root} for valid root-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Root
     {
         return Root::HEAD;
     }

--- a/src/Root/Header.php
+++ b/src/Root/Header.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Root;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<header>` element for section or page header content.
@@ -29,11 +29,11 @@ final class Header extends BaseBlock
     /**
      * Returns the tag enumeration for the `<header>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<header>`.
+     * @return Block Tag enumeration instance for `<header>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::HEADER;
     }

--- a/src/Root/Html.php
+++ b/src/Root/Html.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Root;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{BlockInterface, Root};
+use UIAwesome\Html\Interop\Root;
 
 /**
  * Renders the HTML `<html>` element as the document root.
@@ -29,11 +29,11 @@ final class Html extends BaseBlock
     /**
      * Returns the tag enumeration for the `<html>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<html>`.
+     * @return Root Tag enumeration instance for `<html>`.
      *
      * {@see Root} for valid root-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Root
     {
         return Root::HTML;
     }

--- a/src/Sectioning/Article.php
+++ b/src/Sectioning/Article.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Sectioning;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<article>` element for self-contained content.
@@ -29,11 +29,11 @@ final class Article extends BaseBlock
     /**
      * Returns the tag enumeration for the `<article>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<article>`.
+     * @return Block Tag enumeration instance for `<article>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::ARTICLE;
     }

--- a/src/Sectioning/Aside.php
+++ b/src/Sectioning/Aside.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Sectioning;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<aside>` element for tangentially related content.
@@ -29,11 +29,11 @@ final class Aside extends BaseBlock
     /**
      * Returns the tag enumeration for the `<aside>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<aside>`.
+     * @return Block Tag enumeration instance for `<aside>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::ASIDE;
     }

--- a/src/Sectioning/Nav.php
+++ b/src/Sectioning/Nav.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Sectioning;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<nav>` element for navigation sections.
@@ -29,11 +29,11 @@ final class Nav extends BaseBlock
     /**
      * Returns the tag enumeration for the `<nav>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<nav>`.
+     * @return Block Tag enumeration instance for `<nav>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::NAV;
     }

--- a/src/Sectioning/Section.php
+++ b/src/Sectioning/Section.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Sectioning;
 
 use UIAwesome\Html\Core\Element\BaseBlock;
-use UIAwesome\Html\Interop\{Block, BlockInterface};
+use UIAwesome\Html\Interop\Block;
 
 /**
  * Renders the HTML `<section>` element for standalone document sections.
@@ -29,11 +29,11 @@ final class Section extends BaseBlock
     /**
      * Returns the tag enumeration for the `<section>` element.
      *
-     * @return BlockInterface Tag enumeration instance for `<section>`.
+     * @return Block Tag enumeration instance for `<section>`.
      *
      * {@see Block} for valid block-level tags.
      */
-    protected function getTag(): BlockInterface
+    protected function getTag(): Block
     {
         return Block::SECTION;
     }

--- a/tests/Flow/DivTest.php
+++ b/tests/Flow/DivTest.php
@@ -331,7 +331,7 @@ final class DivTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <div class="default-class" title="default-title">
+            <div class="default-class">
             </div>
             HTML,
             Div::tag()

--- a/tests/Flow/MainTest.php
+++ b/tests/Flow/MainTest.php
@@ -331,7 +331,7 @@ final class MainTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <main class="default-class" title="default-title">
+            <main class="default-class">
             </main>
             HTML,
             Main::tag()

--- a/tests/Flow/PTest.php
+++ b/tests/Flow/PTest.php
@@ -331,7 +331,7 @@ final class PTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <p class="default-class" title="default-title">
+            <p class="default-class">
             </p>
             HTML,
             P::tag()

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -408,7 +408,7 @@ final class FormTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <form class="default-class" title="default-title">
+            <form class="default-class">
             </form>
             HTML,
             Form::tag()

--- a/tests/Form/InputCheckboxTest.php
+++ b/tests/Form/InputCheckboxTest.php
@@ -59,12 +59,10 @@ final class InputCheckboxTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::CHECKBOX,
                 'class' => 'value',
             ],
             InputCheckbox::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -548,18 +546,6 @@ final class InputCheckboxTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputCheckbox::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputcheckbox-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -844,7 +830,7 @@ final class InputCheckboxTest extends TestCase
             <<<HTML
             <input type="checkbox">
             HTML,
-            (string) InputCheckbox::tag()->id(null),
+            (string) InputCheckbox::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputColorTest.php
+++ b/tests/Form/InputColorTest.php
@@ -59,12 +59,10 @@ final class InputColorTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::COLOR,
                 'class' => 'value',
             ],
             InputColor::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -585,18 +583,6 @@ final class InputColorTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputColor::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputcolor-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -897,7 +883,7 @@ final class InputColorTest extends TestCase
             <<<HTML
             <input type="color">
             HTML,
-            (string) InputColor::tag()->id(null),
+            (string) InputColor::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputDateTest.php
+++ b/tests/Form/InputDateTest.php
@@ -58,12 +58,10 @@ final class InputDateTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::DATE,
                 'class' => 'value',
             ],
             InputDate::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -542,18 +540,6 @@ final class InputDateTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputDate::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputdate-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -953,7 +939,7 @@ final class InputDateTest extends TestCase
             <<<HTML
             <input type="date">
             HTML,
-            (string) InputDate::tag()->id(null),
+            (string) InputDate::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputDateTimeLocalTest.php
+++ b/tests/Form/InputDateTimeLocalTest.php
@@ -56,12 +56,10 @@ final class InputDateTimeLocalTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::DATETIME_LOCAL,
                 'class' => 'value',
             ],
             InputDateTimeLocal::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -540,18 +538,6 @@ final class InputDateTimeLocalTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputDateTimeLocal::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputdatetimelocal-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -951,7 +937,7 @@ final class InputDateTimeLocalTest extends TestCase
             <<<HTML
             <input type="datetime-local">
             HTML,
-            (string) InputDateTimeLocal::tag()->id(null),
+            (string) InputDateTimeLocal::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputEmailTest.php
+++ b/tests/Form/InputEmailTest.php
@@ -57,12 +57,10 @@ final class InputEmailTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::EMAIL,
                 'class' => 'value',
             ],
             InputEmail::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -540,18 +538,6 @@ final class InputEmailTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputEmail::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputemail-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -978,7 +964,7 @@ final class InputEmailTest extends TestCase
             <<<HTML
             <input type="email">
             HTML,
-            (string) InputEmail::tag()->id(null),
+            (string) InputEmail::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputFileTest.php
+++ b/tests/Form/InputFileTest.php
@@ -55,13 +55,11 @@ final class InputFileTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::FILE,
                 'class' => 'value',
                 'name' => '',
             ],
             InputFile::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -554,18 +552,6 @@ final class InputFileTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputFile::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputfile-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -864,7 +850,7 @@ final class InputFileTest extends TestCase
             <<<HTML
             <input type="file">
             HTML,
-            (string) InputFile::tag()->id(null),
+            (string) InputFile::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputHiddenTest.php
+++ b/tests/Form/InputHiddenTest.php
@@ -55,12 +55,10 @@ final class InputHiddenTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::HIDDEN,
                 'class' => 'value',
             ],
             InputHidden::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -524,18 +522,6 @@ final class InputHiddenTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputHidden::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputhidden-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -792,7 +778,7 @@ final class InputHiddenTest extends TestCase
             <<<HTML
             <input type="hidden">
             HTML,
-            (string) InputHidden::tag()->id(null),
+            (string) InputHidden::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputImageTest.php
+++ b/tests/Form/InputImageTest.php
@@ -56,12 +56,10 @@ final class InputImageTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::IMAGE,
                 'class' => 'value',
             ],
             InputImage::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -595,18 +593,6 @@ final class InputImageTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputImage::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputimage-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -921,7 +907,7 @@ final class InputImageTest extends TestCase
             <<<HTML
             <input type="image">
             HTML,
-            (string) InputImage::tag()->id(null),
+            (string) InputImage::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputMonthTest.php
+++ b/tests/Form/InputMonthTest.php
@@ -56,12 +56,10 @@ final class InputMonthTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::MONTH,
                 'class' => 'value',
             ],
             InputMonth::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -539,18 +537,6 @@ final class InputMonthTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputMonth::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputmonth-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -950,7 +936,7 @@ final class InputMonthTest extends TestCase
             <<<HTML
             <input type="month">
             HTML,
-            (string) InputMonth::tag()->id(null),
+            (string) InputMonth::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputNumberTest.php
+++ b/tests/Form/InputNumberTest.php
@@ -57,12 +57,10 @@ final class InputNumberTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::NUMBER,
                 'class' => 'value',
             ],
             InputNumber::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -540,18 +538,6 @@ final class InputNumberTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputNumber::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputnumber-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -965,7 +951,7 @@ final class InputNumberTest extends TestCase
             <<<HTML
             <input type="number">
             HTML,
-            (string) InputNumber::tag()->id(null),
+            (string) InputNumber::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputPasswordTest.php
+++ b/tests/Form/InputPasswordTest.php
@@ -58,12 +58,10 @@ final class InputPasswordTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::PASSWORD,
                 'class' => 'value',
             ],
             InputPassword::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -541,18 +539,6 @@ final class InputPasswordTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputPassword::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputpassword-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -965,7 +951,7 @@ final class InputPasswordTest extends TestCase
             <<<HTML
             <input type="password">
             HTML,
-            (string) InputPassword::tag()->id(null),
+            (string) InputPassword::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputRadioTest.php
+++ b/tests/Form/InputRadioTest.php
@@ -61,12 +61,10 @@ final class InputRadioTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::RADIO,
                 'class' => 'value',
             ],
             InputRadio::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -557,18 +555,6 @@ final class InputRadioTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputRadio::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputradio-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -853,7 +839,7 @@ final class InputRadioTest extends TestCase
             <<<HTML
             <input type="radio">
             HTML,
-            (string) InputRadio::tag()->id(null),
+            (string) InputRadio::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputRangeTest.php
+++ b/tests/Form/InputRangeTest.php
@@ -56,12 +56,10 @@ final class InputRangeTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::RANGE,
                 'class' => 'value',
             ],
             InputRange::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -539,18 +537,6 @@ final class InputRangeTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputRange::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputrange-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -922,7 +908,7 @@ final class InputRangeTest extends TestCase
             <<<HTML
             <input type="range">
             HTML,
-            (string) InputRange::tag()->id(null),
+            (string) InputRange::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputResetTest.php
+++ b/tests/Form/InputResetTest.php
@@ -55,12 +55,10 @@ final class InputResetTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::RESET,
                 'class' => 'value',
             ],
             InputReset::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -496,18 +494,6 @@ final class InputResetTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputReset::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputreset-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -794,7 +780,7 @@ final class InputResetTest extends TestCase
             <<<HTML
             <input type="reset">
             HTML,
-            (string) InputReset::tag()->id(null),
+            (string) InputReset::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputSearchTest.php
+++ b/tests/Form/InputSearchTest.php
@@ -57,12 +57,10 @@ final class InputSearchTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::SEARCH,
                 'class' => 'value',
             ],
             InputSearch::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -552,18 +550,6 @@ final class InputSearchTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputSearch::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputsearch-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -976,7 +962,7 @@ final class InputSearchTest extends TestCase
             <<<HTML
             <input type="search">
             HTML,
-            (string) InputSearch::tag()->id(null),
+            (string) InputSearch::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputSubmitTest.php
+++ b/tests/Form/InputSubmitTest.php
@@ -56,12 +56,10 @@ final class InputSubmitTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::SUBMIT,
                 'class' => 'value',
             ],
             InputSubmit::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -623,18 +621,6 @@ final class InputSubmitTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputSubmit::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputsubmit-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -921,7 +907,7 @@ final class InputSubmitTest extends TestCase
             <<<HTML
             <input type="submit">
             HTML,
-            (string) InputSubmit::tag()->id(null),
+            (string) InputSubmit::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputTelTest.php
+++ b/tests/Form/InputTelTest.php
@@ -57,12 +57,10 @@ final class InputTelTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::TEL,
                 'class' => 'value',
             ],
             InputTel::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -540,18 +538,6 @@ final class InputTelTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputTel::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputtel-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -964,7 +950,7 @@ final class InputTelTest extends TestCase
             <<<HTML
             <input type="tel">
             HTML,
-            (string) InputTel::tag()->id(null),
+            (string) InputTel::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputTextTest.php
+++ b/tests/Form/InputTextTest.php
@@ -59,12 +59,10 @@ final class InputTextTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::TEXT,
                 'class' => 'value',
             ],
             InputText::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -556,18 +554,6 @@ final class InputTextTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputText::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputtext-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -980,7 +966,7 @@ final class InputTextTest extends TestCase
             <<<HTML
             <input type="text">
             HTML,
-            (string) InputText::tag()->id(null),
+            (string) InputText::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputTimeTest.php
+++ b/tests/Form/InputTimeTest.php
@@ -58,12 +58,10 @@ final class InputTimeTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::TIME,
                 'class' => 'value',
             ],
             InputTime::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -541,18 +539,6 @@ final class InputTimeTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputTime::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputtime-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -952,7 +938,7 @@ final class InputTimeTest extends TestCase
             <<<HTML
             <input type="time">
             HTML,
-            (string) InputTime::tag()->id(null),
+            (string) InputTime::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputUrlTest.php
+++ b/tests/Form/InputUrlTest.php
@@ -59,12 +59,10 @@ final class InputUrlTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::URL,
                 'class' => 'value',
             ],
             InputUrl::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -542,18 +540,6 @@ final class InputUrlTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputUrl::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputurl-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -966,7 +952,7 @@ final class InputUrlTest extends TestCase
             <<<HTML
             <input type="url">
             HTML,
-            (string) InputUrl::tag()->id(null),
+            (string) InputUrl::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/InputWeekTest.php
+++ b/tests/Form/InputWeekTest.php
@@ -58,12 +58,10 @@ final class InputWeekTest extends TestCase
     {
         self::assertSame(
             [
-                'id' => null,
                 'type' => Type::WEEK,
                 'class' => 'value',
             ],
             InputWeek::tag()
-                ->id(null)
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -542,18 +540,6 @@ final class InputWeekTest extends TestCase
         );
     }
 
-    public function testRenderWithGenerateId(): void
-    {
-        /** @phpstan-var string $id */
-        $id = InputWeek::tag()->getAttribute('id', '');
-
-        self::assertMatchesRegularExpression(
-            '/^inputweek-\w+$/',
-            $id,
-            'Failed asserting that element generates an ID when not provided.',
-        );
-    }
-
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
@@ -953,7 +939,7 @@ final class InputWeekTest extends TestCase
             <<<HTML
             <input type="week">
             HTML,
-            (string) InputWeek::tag()->id(null),
+            (string) InputWeek::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
         );
     }

--- a/tests/Form/TextAreaTest.php
+++ b/tests/Form/TextAreaTest.php
@@ -420,7 +420,7 @@ final class TextAreaTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <textarea class="default-class" title="default-title">
+            <textarea class="default-class">
             </textarea>
             HTML,
             TextArea::tag()

--- a/tests/Heading/H1Test.php
+++ b/tests/Heading/H1Test.php
@@ -316,7 +316,7 @@ final class H1Test extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <h1 class="default-class" title="default-title">
+            <h1 class="default-class">
             </h1>
             HTML,
             H1::tag()

--- a/tests/Heading/H2Test.php
+++ b/tests/Heading/H2Test.php
@@ -316,7 +316,7 @@ final class H2Test extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <h2 class="default-class" title="default-title">
+            <h2 class="default-class">
             </h2>
             HTML,
             H2::tag()

--- a/tests/Heading/H3Test.php
+++ b/tests/Heading/H3Test.php
@@ -316,7 +316,7 @@ final class H3Test extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <h3 class="default-class" title="default-title">
+            <h3 class="default-class">
             </h3>
             HTML,
             H3::tag()

--- a/tests/Heading/H4Test.php
+++ b/tests/Heading/H4Test.php
@@ -316,7 +316,7 @@ final class H4Test extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <h4 class="default-class" title="default-title">
+            <h4 class="default-class">
             </h4>
             HTML,
             H4::tag()

--- a/tests/Heading/H5Test.php
+++ b/tests/Heading/H5Test.php
@@ -316,7 +316,7 @@ final class H5Test extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <h5 class="default-class" title="default-title">
+            <h5 class="default-class">
             </h5>
             HTML,
             H5::tag()

--- a/tests/Heading/H6Test.php
+++ b/tests/Heading/H6Test.php
@@ -316,7 +316,7 @@ final class H6Test extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <h6 class="default-class" title="default-title">
+            <h6 class="default-class">
             </h6>
             HTML,
             H6::tag()

--- a/tests/Heading/HGroupTest.php
+++ b/tests/Heading/HGroupTest.php
@@ -316,7 +316,7 @@ final class HGroupTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <hgroup class="default-class" title="default-title">
+            <hgroup class="default-class">
             </hgroup>
             HTML,
             HGroup::tag()

--- a/tests/List/DdTest.php
+++ b/tests/List/DdTest.php
@@ -316,7 +316,7 @@ final class DdTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <dd class="default-class" title="default-title">
+            <dd class="default-class">
             </dd>
             HTML,
             Dd::tag()

--- a/tests/List/DlTest.php
+++ b/tests/List/DlTest.php
@@ -337,7 +337,7 @@ final class DlTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <dl class="default-class" title="default-title">
+            <dl class="default-class">
             </dl>
             HTML,
             Dl::tag()

--- a/tests/List/DtTest.php
+++ b/tests/List/DtTest.php
@@ -316,7 +316,7 @@ final class DtTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <dt class="default-class" title="default-title">
+            <dt class="default-class">
             </dt>
             HTML,
             Dt::tag()

--- a/tests/List/LiTest.php
+++ b/tests/List/LiTest.php
@@ -317,7 +317,7 @@ final class LiTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <li class="default-class" title="default-title">
+            <li class="default-class">
             </li>
             HTML,
             Li::tag()

--- a/tests/List/OlTest.php
+++ b/tests/List/OlTest.php
@@ -319,7 +319,7 @@ final class OlTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <ol class="default-class" title="default-title">
+            <ol class="default-class">
             </ol>
             HTML,
             Ol::tag()

--- a/tests/List/UlTest.php
+++ b/tests/List/UlTest.php
@@ -306,7 +306,7 @@ final class UlTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <ul class="default-class" title="default-title">
+            <ul class="default-class">
             </ul>
             HTML,
             Ul::tag()

--- a/tests/Metadata/NoScriptTest.php
+++ b/tests/Metadata/NoScriptTest.php
@@ -316,7 +316,7 @@ final class NoScriptTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <noscript class="default-class" title="default-title">
+            <noscript class="default-class">
             </noscript>
             HTML,
             NoScript::tag()

--- a/tests/Metadata/ScriptTest.php
+++ b/tests/Metadata/ScriptTest.php
@@ -395,7 +395,7 @@ final class ScriptTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <script class="default-class" title="default-title">
+            <script class="default-class">
             </script>
             HTML,
             Script::tag()

--- a/tests/Metadata/StyleTest.php
+++ b/tests/Metadata/StyleTest.php
@@ -349,7 +349,7 @@ final class StyleTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <style class="default-class" title="default-title">
+            <style class="default-class">
             </style>
             HTML,
             Style::tag()

--- a/tests/Metadata/TemplateTest.php
+++ b/tests/Metadata/TemplateTest.php
@@ -320,7 +320,7 @@ final class TemplateTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <template class="default-class" title="default-title">
+            <template class="default-class">
             </template>
             HTML,
             Template::tag()

--- a/tests/Metadata/TitleTest.php
+++ b/tests/Metadata/TitleTest.php
@@ -316,7 +316,7 @@ final class TitleTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <title class="default-class" title="default-title">
+            <title class="default-class">
             </title>
             HTML,
             Title::tag()

--- a/tests/Root/BodyTest.php
+++ b/tests/Root/BodyTest.php
@@ -316,7 +316,7 @@ final class BodyTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <body class="default-class" title="default-title">
+            <body class="default-class">
             </body>
             HTML,
             Body::tag()

--- a/tests/Root/FooterTest.php
+++ b/tests/Root/FooterTest.php
@@ -316,7 +316,7 @@ final class FooterTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <footer class="default-class" title="default-title">
+            <footer class="default-class">
             </footer>
             HTML,
             Footer::tag()

--- a/tests/Root/HeadTest.php
+++ b/tests/Root/HeadTest.php
@@ -316,7 +316,7 @@ final class HeadTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <head class="default-class" title="default-title">
+            <head class="default-class">
             </head>
             HTML,
             Head::tag()

--- a/tests/Root/HeaderTest.php
+++ b/tests/Root/HeaderTest.php
@@ -316,7 +316,7 @@ final class HeaderTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <header class="default-class" title="default-title">
+            <header class="default-class">
             </header>
             HTML,
             Header::tag()

--- a/tests/Root/HtmlTest.php
+++ b/tests/Root/HtmlTest.php
@@ -316,7 +316,7 @@ final class HtmlTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <html class="default-class" title="default-title">
+            <html class="default-class">
             </html>
             HTML,
             Html::tag()

--- a/tests/Sectioning/ArticleTest.php
+++ b/tests/Sectioning/ArticleTest.php
@@ -316,7 +316,7 @@ final class ArticleTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <article class="default-class" title="default-title">
+            <article class="default-class">
             </article>
             HTML,
             Article::tag()

--- a/tests/Sectioning/AsideTest.php
+++ b/tests/Sectioning/AsideTest.php
@@ -316,7 +316,7 @@ final class AsideTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <aside class="default-class" title="default-title">
+            <aside class="default-class">
             </aside>
             HTML,
             Aside::tag()

--- a/tests/Sectioning/NavTest.php
+++ b/tests/Sectioning/NavTest.php
@@ -316,7 +316,7 @@ final class NavTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <nav class="default-class" title="default-title">
+            <nav class="default-class">
             </nav>
             HTML,
             Nav::tag()

--- a/tests/Sectioning/SectionTest.php
+++ b/tests/Sectioning/SectionTest.php
@@ -316,7 +316,7 @@ final class SectionTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <section class="default-class" title="default-title">
+            <section class="default-class">
             </section>
             HTML,
             Section::tag()

--- a/tests/Support/Stub/DefaultProvider.php
+++ b/tests/Support/Stub/DefaultProvider.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Tests\Support\Stub;
 
+use UIAwesome\Html\Contracts\Element\BlockInterface;
 use UIAwesome\Html\Core\Base\BaseTag;
 use UIAwesome\Html\Core\Provider\DefaultsProviderInterface;
-use UIAwesome\Html\Interop\BlockInterface;
 
 /**
  * Stub defaults provider for tests.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
