### PR TITLE
feat(table): Add `Caption` class for HTML `<caption>` element with attributes and rendering capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Enh #67: Add `Output` class for HTML `<output>` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #68: Add `Progress` class for HTML `<progress>` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #69: Add `Meter` class for HTML `<meter>` element with attributes and rendering capabilities (@terabytesoftw)
+- Enh #70: Add `Caption` class for HTML `<caption>` element with attributes and rendering capabilities (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Table/Caption.php
+++ b/src/Table/Caption.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Table;
+
+use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Interop\Table;
+
+/**
+ * Renders the HTML `<caption>` element for table captions.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Table\Caption::tag()
+ *     ->content('Monthly sales report')
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/caption
+ * {@see BaseBlock} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class Caption extends BaseBlock
+{
+    /**
+     * Returns the tag enumeration for the `<caption>` element.
+     *
+     * @return Table Tag enumeration instance for `<caption>`.
+     *
+     * {@see Table} for valid table tags.
+     */
+    protected function getTag(): Table
+    {
+        return Table::CAPTION;
+    }
+}

--- a/tests/Table/CaptionTest.php
+++ b/tests/Table/CaptionTest.php
@@ -1,0 +1,863 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Table;
+
+use InvalidArgumentException;
+use PHPForge\Support\Stub\BackedString;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{
+    Aria,
+    ContentEditable,
+    Data,
+    Direction,
+    Draggable,
+    GlobalAttribute,
+    Language,
+    Role,
+    Translate,
+};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Helper\Enum;
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Table\Caption;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see Caption} rendering and global attribute behavior.
+ *
+ * Test coverage.
+ * - Applies global and custom attributes, including `aria-*`, `data-*`, `on*` and enum-backed values.
+ * - Ensures attribute accessors return assigned values and fallback defaults.
+ * - Renders content, raw HTML, and string casting with expected encoding behavior.
+ * - Resolves default and theme providers, including global defaults and user overrides.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('table')]
+final class CaptionTest extends TestCase
+{
+    public function testContentEncodesValues(): void
+    {
+        self::assertSame(
+            '&lt;value&gt;',
+            Caption::tag()
+                ->content('<value>')
+                ->getContent(),
+            "Failed asserting that 'content()' method encodes values correctly.",
+        );
+    }
+
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'value',
+            Caption::tag()->getAttribute('class', 'value'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testGetAttributesReturnsAssignedAttributes(): void
+    {
+        self::assertSame(
+            ['class' => 'value'],
+            Caption::tag()
+                ->setAttribute('class', 'value')
+                ->getAttributes(),
+            "Failed asserting that 'getAttributes()' returns the assigned attributes.",
+        );
+    }
+
+    public function testHtmlDoesNotEncodeValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption>
+            <value>
+            </caption>
+            HTML,
+            Caption::tag()
+                ->html('<value>')
+                ->render(),
+            "Failed asserting that element renders correctly with 'html()' method.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption accesskey="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->accesskey('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption aria-label="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->addAriaAttribute('label', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption aria-label="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->addAriaAttribute(Aria::LABEL, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption data-value="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->addDataAttribute('value', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption data-value="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->addDataAttribute(Data::VALUE, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption onclick="alert(&apos;Clicked!&apos;)">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->render(),
+            "Failed asserting that element renders correctly with 'addEvent()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption aria-controls="value" aria-label="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->ariaAttributes(
+                    [
+                        'controls' => 'value',
+                        'label' => 'value',
+                    ],
+                )
+                ->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption class="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->attributes(['class' => 'value'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption autofocus>
+            </caption>
+            HTML,
+            Caption::tag()
+                ->autofocus(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'autofocus' attribute.",
+        );
+    }
+
+    public function testRenderWithBeginEnd(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption>
+            Content
+            </caption>
+            HTML,
+            Caption::tag()->begin() . 'Content' . Caption::end(),
+            "Failed asserting that element renders correctly with 'begin()' and 'end()' methods.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption class="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->class('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithClassUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption class="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->class(BackedString::VALUE)
+                ->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithContent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption>
+            value
+            </caption>
+            HTML,
+            Caption::tag()
+                ->content('value')
+                ->render(),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithContentEditable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption contenteditable="true">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->contentEditable(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute.",
+        );
+    }
+
+    public function testRenderWithContentEditableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption contenteditable="true">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->contentEditable(ContentEditable::TRUE)
+                ->render(),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption data-value="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->dataAttributes(['value' => 'value'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption class="default-class">
+            </caption>
+            HTML,
+            Caption::tag(['class' => 'default-class'])->render(),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption class="default-class">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->render(),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption dir="ltr">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->dir('ltr')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption dir="ltr">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->dir(Direction::LTR)
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDraggable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption draggable="true">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->draggable(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'draggable' attribute.",
+        );
+    }
+
+    public function testRenderWithDraggableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption draggable="true">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->draggable(Draggable::TRUE)
+                ->render(),
+            "Failed asserting that element renders correctly with 'draggable' attribute.",
+        );
+    }
+
+    public function testRenderWithEvents(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption onfocus="handleFocus()" onblur="handleBlur()">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->events(
+                    [
+                        'focus' => 'handleFocus()',
+                        'blur' => 'handleBlur()',
+                    ],
+                )
+                ->render(),
+            "Failed asserting that element renders correctly with 'events()' method.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(
+            Caption::class,
+            ['class' => 'default-class'],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <caption class="default-class">
+            </caption>
+            HTML,
+            Caption::tag()->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            Caption::class,
+            [],
+        );
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption hidden>
+            </caption>
+            HTML,
+            Caption::tag()
+                ->hidden(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption id="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->id('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption lang="en">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->lang('en')
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption lang="en">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->lang(Language::ENGLISH)
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithMicroData(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption itemid="https://example.com/item" itemprop="name" itemref="info" itemscope itemtype="https://schema.org/Thing">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->itemId('https://example.com/item')
+                ->itemProp('name')
+                ->itemRef('info')
+                ->itemScope(true)
+                ->itemType('https://schema.org/Thing')
+                ->render(),
+            'Failed asserting that element renders correctly with microdata attributes.',
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption>
+            </caption>
+            HTML,
+            Caption::tag()
+                ->addAriaAttribute('label', 'value')
+                ->removeAriaAttribute('label')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption>
+            </caption>
+            HTML,
+            Caption::tag()
+                ->setAttribute('class', 'value')
+                ->removeAttribute('class')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption>
+            </caption>
+            HTML,
+            Caption::tag()
+                ->addDataAttribute('value', 'value')
+                ->removeDataAttribute('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption>
+            </caption>
+            HTML,
+            Caption::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->removeEvent('click')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeEvent()' method.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption role="banner">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->role('banner')
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption role="banner">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->role(Role::BANNER)
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithSetAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption class="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->setAttribute('class', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithSetAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption title="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->setAttribute(GlobalAttribute::TITLE, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithSpellcheck(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption spellcheck="true">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->spellcheck(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'spellcheck' attribute.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption style='value'>
+            </caption>
+            HTML,
+            Caption::tag()
+                ->style('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption tabindex="3">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->tabIndex(3)
+                ->render(),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption class="text-muted">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->addThemeProvider('muted', DefaultThemeProvider::class)
+                ->render(),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption title="value">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->title('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption>
+            </caption>
+            HTML,
+            (string) Caption::tag(),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption translate="no">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->translate(false)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <caption translate="no">
+            </caption>
+            HTML,
+            Caption::tag()
+                ->translate(Translate::NO)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(
+            Caption::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <caption class="from-global" id="value">
+            </caption>
+            HTML,
+            Caption::tag(['id' => 'value'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            Caption::class,
+            [],
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingContentEditable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::CONTENTEDITABLE->value,
+                implode("', '", Enum::normalizeArray(ContentEditable::cases())),
+            ),
+        );
+
+        Caption::tag()->contentEditable('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingDir(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::DIR->value,
+                implode("', '", Enum::normalizeArray(Direction::cases())),
+            ),
+        );
+
+        Caption::tag()->dir('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingDraggable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::DRAGGABLE->value,
+                implode("', '", Enum::normalizeArray(Draggable::cases())),
+            ),
+        );
+
+        Caption::tag()->draggable('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingLang(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::LANG->value,
+                implode("', '", Enum::normalizeArray(Language::cases())),
+            ),
+        );
+
+        Caption::tag()->lang('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingRole(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::ROLE->value,
+                implode("', '", Enum::normalizeArray(Role::cases())),
+            ),
+        );
+
+        Caption::tag()->role('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingTabindex(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            \UIAwesome\Html\Attribute\Exception\Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                '-2',
+                GlobalAttribute::TABINDEX->value,
+                'value >= -1',
+            ),
+        );
+
+        Caption::tag()->tabIndex(-2);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingTranslate(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::TRANSLATE->value,
+                implode("', '", Enum::normalizeArray(Translate::cases())),
+            ),
+        );
+
+        Caption::tag()->translate('invalid-value');
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
