### PR TITLE
feat(table): Add `Td` class for HTML `<td>` element with attributes and rendering capabilities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Enh #68: Add `Progress` class for HTML `<progress>` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #69: Add `Meter` class for HTML `<meter>` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #70: Add `Caption` class for HTML `<caption>` element with attributes and rendering capabilities (@terabytesoftw)
+- Enh #71: Add `Td` class for HTML `<td>` element with attributes and rendering capabilities (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Table/Attribute/HasColspan.php
+++ b/src/Table/Attribute/HasColspan.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Table\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Exception\Message;
+use UIAwesome\Html\Helper\Validator;
+
+/**
+ * Provides an immutable API for the HTML `colspan` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td#colspan
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasColspan
+{
+    /**
+     * Sets the `colspan` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Table\Td::tag()
+     *     ->colspan(2)
+     *     ->render();
+     * ```
+     *
+     * @param int|string|null $value Number of columns a cell spans (`1` to `1000`), or `null` to remove the
+     * attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not an integer-like value between `1` and `1000`.
+     *
+     * @return static New instance with the updated `colspan` attribute.
+     */
+    public function colspan(int|string|null $value): static
+    {
+        if ($value !== null && Validator::intLike($value, 1, 1000) === false) {
+            throw new InvalidArgumentException(
+                Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                    (string) $value,
+                    'colspan',
+                    '1 <= value <= 1000',
+                ),
+            );
+        }
+
+        return $this->setAttribute('colspan', $value);
+    }
+}

--- a/src/Table/Attribute/HasHeaders.php
+++ b/src/Table/Attribute/HasHeaders.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Table\Attribute;
+
+use UnitEnum;
+
+/**
+ * Provides an immutable API for the HTML `headers` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td#headers
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasHeaders
+{
+    /**
+     * Sets the `headers` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Table\Td::tag()
+     *     ->headers('name age')
+     *     ->render();
+     * ```
+     *
+     * @param string|UnitEnum|null $value Space-separated list of header cell IDs, or `null` to remove the attribute.
+     *
+     * @return static New instance with the updated `headers` attribute.
+     */
+    public function headers(string|UnitEnum|null $value): static
+    {
+        return $this->setAttribute('headers', $value);
+    }
+}

--- a/src/Table/Attribute/HasRowspan.php
+++ b/src/Table/Attribute/HasRowspan.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Table\Attribute;
+
+use InvalidArgumentException;
+use UIAwesome\Html\Attribute\Exception\Message;
+use UIAwesome\Html\Helper\Validator;
+
+/**
+ * Provides an immutable API for the HTML `rowspan` attribute.
+ *
+ * @mixin \UIAwesome\Html\Mixin\HasAttributes
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td#rowspan
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+trait HasRowspan
+{
+    /**
+     * Sets the `rowspan` attribute.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Table\Td::tag()
+     *     ->rowspan(2)
+     *     ->render();
+     * ```
+     *
+     * @param int|string|null $value Number of rows a cell spans (`0` to `65534`), or `null` to remove the attribute.
+     *
+     * @throws InvalidArgumentException if the provided value is not an integer-like value between `0` and `65534`.
+     *
+     * @return static New instance with the updated `rowspan` attribute.
+     */
+    public function rowspan(int|string|null $value): static
+    {
+        if ($value !== null && Validator::intLike($value, 0, 65534) === false) {
+            throw new InvalidArgumentException(
+                Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                    (string) $value,
+                    'rowspan',
+                    '0 <= value <= 65534',
+                ),
+            );
+        }
+
+        return $this->setAttribute('rowspan', $value);
+    }
+}

--- a/src/Table/Td.php
+++ b/src/Table/Td.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Table;
+
+use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Interop\Table;
+use UIAwesome\Html\Table\Attribute\{HasColspan, HasHeaders, HasRowspan};
+
+/**
+ * Renders the HTML `<td>` element for table data cells.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Table\Td::tag()
+ *     ->colspan(2)
+ *     ->content('Total')
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td
+ * {@see BaseBlock} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class Td extends BaseBlock
+{
+    use HasColspan;
+    use HasHeaders;
+    use HasRowspan;
+
+    /**
+     * Returns the tag enumeration for the `<td>` element.
+     *
+     * @return Table Tag enumeration instance for `<td>`.
+     *
+     * {@see Table} for valid table tags.
+     */
+    protected function getTag(): Table
+    {
+        return Table::TD;
+    }
+}

--- a/tests/Provider/Table/TdProvider.php
+++ b/tests/Provider/Table/TdProvider.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Provider\Table;
+
+/**
+ * Data provider for {@see \UIAwesome\Html\Tests\Table\TdTest} test cases.
+ *
+ * Provides boundary and numeric-string input/output pairs for the `colspan` and `rowspan` attributes.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TdProvider
+{
+    /**
+     * @return array<string, array{int|string, string}>
+     */
+    public static function colspanValues(): array
+    {
+        return [
+            'max int' => [
+                1000,
+                <<<HTML
+                <td colspan="1000">
+                </td>
+                HTML,
+            ],
+            'max string' => [
+                '1000',
+                <<<HTML
+                <td colspan="1000">
+                </td>
+                HTML,
+            ],
+            'min int' => [
+                1,
+                <<<HTML
+                <td colspan="1">
+                </td>
+                HTML,
+            ],
+            'min string' => [
+                '1',
+                <<<HTML
+                <td colspan="1">
+                </td>
+                HTML,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{int|string, string}>
+     */
+    public static function rowspanValues(): array
+    {
+        return [
+            'max int' => [
+                65534,
+                <<<HTML
+                <td rowspan="65534">
+                </td>
+                HTML,
+            ],
+            'max string' => [
+                '65534',
+                <<<HTML
+                <td rowspan="65534">
+                </td>
+                HTML,
+            ],
+            'min int' => [
+                0,
+                <<<HTML
+                <td rowspan="0">
+                </td>
+                HTML,
+            ],
+            'min string' => [
+                '0',
+                <<<HTML
+                <td rowspan="0">
+                </td>
+                HTML,
+            ],
+        ];
+    }
+}

--- a/tests/Table/TdTest.php
+++ b/tests/Table/TdTest.php
@@ -1,0 +1,977 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Table;
+
+use InvalidArgumentException;
+use PHPForge\Support\Stub\BackedString;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{
+    Aria,
+    ContentEditable,
+    Data,
+    Direction,
+    Draggable,
+    GlobalAttribute,
+    Language,
+    Role,
+    Translate,
+};
+use UIAwesome\Html\Core\Factory\SimpleFactory;
+use UIAwesome\Html\Helper\Enum;
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Table\Td;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see Td} rendering and table cell attribute behavior.
+ *
+ * Test coverage.
+ * - Applies global and custom attributes, including `aria-*`, `data-*` and enum-backed values.
+ * - Applies table cell specific attributes (`colspan`, `headers`, `rowspan`) and renders expected output.
+ * - Covers `colspan` and `rowspan` boundary values for minimum and maximum valid limits.
+ * - Ensures attribute accessors return assigned values and fallback defaults.
+ * - Renders content, raw HTML, begin/end usage, and string casting with expected encoding behavior.
+ * - Resolves default and theme providers, including global defaults and user overrides.
+ * - Verifies invalid values throw {@see InvalidArgumentException}.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Group('table')]
+final class TdTest extends TestCase
+{
+    public function testContentEncodesValues(): void
+    {
+        self::assertSame(
+            '&lt;value&gt;',
+            Td::tag()
+                ->content('<value>')
+                ->getContent(),
+            "Failed asserting that 'content()' method encodes values correctly.",
+        );
+    }
+
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'value',
+            Td::tag()->getAttribute('class', 'value'),
+            "Failed asserting that 'getAttribute()' returns the default value when missing.",
+        );
+    }
+
+    public function testGetAttributesReturnsAssignedAttributes(): void
+    {
+        self::assertSame(
+            ['class' => 'value'],
+            Td::tag()
+                ->setAttribute('class', 'value')
+                ->getAttributes(),
+            "Failed asserting that 'getAttributes()' returns the assigned attributes.",
+        );
+    }
+
+    public function testHtmlDoesNotEncodeValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td>
+            <value>
+            </td>
+            HTML,
+            Td::tag()
+                ->html('<value>')
+                ->render(),
+            "Failed asserting that element renders correctly with 'html()' method.",
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td accesskey="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->accesskey('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'accesskey' attribute.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td aria-label="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->addAriaAttribute('label', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td aria-label="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->addAriaAttribute(Aria::LABEL, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td data-value="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->addDataAttribute('value', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td data-value="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->addDataAttribute(Data::VALUE, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td aria-controls="value" aria-label="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->ariaAttributes(
+                    [
+                        'controls' => 'value',
+                        'label' => 'value',
+                    ],
+                )
+                ->render(),
+            "Failed asserting that element renders correctly with 'ariaAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td class="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->attributes(['class' => 'value'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'attributes()' method.",
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td autofocus>
+            </td>
+            HTML,
+            Td::tag()
+                ->autofocus(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'autofocus' attribute.",
+        );
+    }
+
+    public function testRenderWithBeginEnd(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td>
+            Content
+            </td>
+            HTML,
+            Td::tag()->begin() . 'Content' . Td::end(),
+            "Failed asserting that element renders correctly with 'begin()' and 'end()' methods.",
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td class="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->class('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithClassUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td class="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->class(BackedString::VALUE)
+                ->render(),
+            "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithColspanMaxValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td colspan="1000">
+            </td>
+            HTML,
+            Td::tag()
+                ->colspan(1000)
+                ->render(),
+            "Failed asserting that element renders correctly with 'colspan' attribute.",
+        );
+    }
+
+    public function testRenderWithColspanMinValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td colspan="1">
+            </td>
+            HTML,
+            Td::tag()
+                ->colspan(1)
+                ->render(),
+            "Failed asserting that element renders correctly with 'colspan' attribute.",
+        );
+    }
+
+    public function testRenderWithContent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td>
+            value
+            </td>
+            HTML,
+            Td::tag()
+                ->content('value')
+                ->render(),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithContentEditable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td contenteditable="true">
+            </td>
+            HTML,
+            Td::tag()
+                ->contentEditable(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute.",
+        );
+    }
+
+    public function testRenderWithContentEditableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td contenteditable="true">
+            </td>
+            HTML,
+            Td::tag()
+                ->contentEditable(ContentEditable::TRUE)
+                ->render(),
+            "Failed asserting that element renders correctly with 'contentEditable' attribute.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td data-value="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->dataAttributes(['value' => 'value'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'dataAttributes()' method.",
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td class="default-class">
+            </td>
+            HTML,
+            Td::tag(['class' => 'default-class'])->render(),
+            'Failed asserting that default configuration values are applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td class="default-class">
+            </td>
+            HTML,
+            Td::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->render(),
+            'Failed asserting that default provider is applied correctly.',
+        );
+    }
+
+    public function testRenderWithDefaultValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td>
+            </td>
+            HTML,
+            Td::tag()->render(),
+            'Failed asserting that element renders correctly with default values.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td dir="ltr">
+            </td>
+            HTML,
+            Td::tag()
+                ->dir('ltr')
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td dir="ltr">
+            </td>
+            HTML,
+            Td::tag()
+                ->dir(Direction::LTR)
+                ->render(),
+            "Failed asserting that element renders correctly with 'dir' attribute.",
+        );
+    }
+
+    public function testRenderWithDraggable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td draggable="true">
+            </td>
+            HTML,
+            Td::tag()
+                ->draggable(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'draggable' attribute.",
+        );
+    }
+
+    public function testRenderWithDraggableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td draggable="true">
+            </td>
+            HTML,
+            Td::tag()
+                ->draggable(Draggable::TRUE)
+                ->render(),
+            "Failed asserting that element renders correctly with 'draggable' attribute.",
+        );
+    }
+
+    public function testRenderWithGlobalDefaultsAreApplied(): void
+    {
+        SimpleFactory::setDefaults(
+            Td::class,
+            ['class' => 'default-class'],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <td class="default-class">
+            </td>
+            HTML,
+            Td::tag()->render(),
+            'Failed asserting that global defaults are applied correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            Td::class,
+            [],
+        );
+    }
+
+    public function testRenderWithHeaders(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td headers="h1 h2">
+            </td>
+            HTML,
+            Td::tag()
+                ->headers('h1 h2')
+                ->render(),
+            "Failed asserting that element renders correctly with 'headers' attribute.",
+        );
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td hidden>
+            </td>
+            HTML,
+            Td::tag()
+                ->hidden(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'hidden' attribute.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td id="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->id('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'id' attribute.",
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td lang="en">
+            </td>
+            HTML,
+            Td::tag()
+                ->lang('en')
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td lang="en">
+            </td>
+            HTML,
+            Td::tag()
+                ->lang(Language::ENGLISH)
+                ->render(),
+            "Failed asserting that element renders correctly with 'lang' attribute.",
+        );
+    }
+
+    public function testRenderWithMicroData(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td itemid="https://example.com/item" itemprop="name" itemref="info" itemscope itemtype="https://schema.org/Thing">
+            </td>
+            HTML,
+            Td::tag()
+                ->itemId('https://example.com/item')
+                ->itemProp('name')
+                ->itemRef('info')
+                ->itemScope(true)
+                ->itemType('https://schema.org/Thing')
+                ->render(),
+            'Failed asserting that element renders correctly with microdata attributes.',
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td>
+            </td>
+            HTML,
+            Td::tag()
+                ->addAriaAttribute('label', 'value')
+                ->removeAriaAttribute('label')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAriaAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td>
+            </td>
+            HTML,
+            Td::tag()
+                ->setAttribute('class', 'value')
+                ->removeAttribute('class')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td>
+            </td>
+            HTML,
+            Td::tag()
+                ->addDataAttribute('value', 'value')
+                ->removeDataAttribute('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'removeDataAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td role="banner">
+            </td>
+            HTML,
+            Td::tag()
+                ->role('banner')
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td role="banner">
+            </td>
+            HTML,
+            Td::tag()
+                ->role(Role::BANNER)
+                ->render(),
+            "Failed asserting that element renders correctly with 'role' attribute.",
+        );
+    }
+
+    public function testRenderWithRowspanMaxValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td rowspan="65534">
+            </td>
+            HTML,
+            Td::tag()
+                ->rowspan(65534)
+                ->render(),
+            "Failed asserting that element renders correctly with 'rowspan' attribute.",
+        );
+    }
+
+    public function testRenderWithRowspanMinValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td rowspan="0">
+            </td>
+            HTML,
+            Td::tag()
+                ->rowspan(0)
+                ->render(),
+            "Failed asserting that element renders correctly with 'rowspan' attribute.",
+        );
+    }
+
+    public function testRenderWithSetAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td class="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->setAttribute('class', 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithSetAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td title="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->setAttribute(GlobalAttribute::TITLE, 'value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'setAttribute()' method.",
+        );
+    }
+
+    public function testRenderWithSpellcheck(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td spellcheck="true">
+            </td>
+            HTML,
+            Td::tag()
+                ->spellcheck(true)
+                ->render(),
+            "Failed asserting that element renders correctly with 'spellcheck' attribute.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td style='value'>
+            </td>
+            HTML,
+            Td::tag()
+                ->style('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'style' attribute.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td tabindex="3">
+            </td>
+            HTML,
+            Td::tag()
+                ->tabIndex(3)
+                ->render(),
+            "Failed asserting that element renders correctly with 'tabindex' attribute.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td class="text-muted">
+            </td>
+            HTML,
+            Td::tag()
+                ->addThemeProvider('muted', DefaultThemeProvider::class)
+                ->render(),
+            "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td title="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->title('value')
+                ->render(),
+            "Failed asserting that element renders correctly with 'title' attribute.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td>
+            </td>
+            HTML,
+            (string) Td::tag(),
+            "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td translate="no">
+            </td>
+            HTML,
+            Td::tag()
+                ->translate(false)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td translate="no">
+            </td>
+            HTML,
+            Td::tag()
+                ->translate(Translate::NO)
+                ->render(),
+            "Failed asserting that element renders correctly with 'translate' attribute.",
+        );
+    }
+
+    public function testRenderWithUserOverridesGlobalDefaults(): void
+    {
+        SimpleFactory::setDefaults(
+            Td::class,
+            [
+                'class' => 'from-global',
+                'id' => 'id-global',
+            ],
+        );
+
+        self::assertSame(
+            <<<HTML
+            <td class="from-global" id="value">
+            </td>
+            HTML,
+            Td::tag(['id' => 'value'])->render(),
+            'Failed asserting that user-defined attributes override global defaults correctly.',
+        );
+
+        SimpleFactory::setDefaults(
+            Td::class,
+            [],
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAttribute(): void
+    {
+        $td = Td::tag();
+
+        self::assertNotSame(
+            $td,
+            $td->colspan(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $td,
+            $td->headers(''),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $td,
+            $td->rowspan(null),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingColspanMaxValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            \UIAwesome\Html\Attribute\Exception\Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                '1001',
+                'colspan',
+                '1 <= value <= 1000',
+            ),
+        );
+
+        Td::tag()->colspan(1001);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingColspanMinValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            \UIAwesome\Html\Attribute\Exception\Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                '0',
+                'colspan',
+                '1 <= value <= 1000',
+            ),
+        );
+
+        Td::tag()->colspan(0);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingContentEditable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::CONTENTEDITABLE->value,
+                implode("', '", Enum::normalizeArray(ContentEditable::cases())),
+            ),
+        );
+
+        Td::tag()->contentEditable('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingDir(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::DIR->value,
+                implode("', '", Enum::normalizeArray(Direction::cases())),
+            ),
+        );
+
+        Td::tag()->dir('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingDraggable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::DRAGGABLE->value,
+                implode("', '", Enum::normalizeArray(Draggable::cases())),
+            ),
+        );
+
+        Td::tag()->draggable('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingLang(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::LANG->value,
+                implode("', '", Enum::normalizeArray(Language::cases())),
+            ),
+        );
+
+        Td::tag()->lang('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingRole(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::ROLE->value,
+                implode("', '", Enum::normalizeArray(Role::cases())),
+            ),
+        );
+
+        Td::tag()->role('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingRowspanMaxValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            \UIAwesome\Html\Attribute\Exception\Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                '65535',
+                'rowspan',
+                '0 <= value <= 65534',
+            ),
+        );
+
+        Td::tag()->rowspan(65535);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingRowspanMinValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            \UIAwesome\Html\Attribute\Exception\Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                '-1',
+                'rowspan',
+                '0 <= value <= 65534',
+            ),
+        );
+
+        Td::tag()->rowspan(-1);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingTabindex(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            \UIAwesome\Html\Attribute\Exception\Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                '-2',
+                GlobalAttribute::TABINDEX->value,
+                'value >= -1',
+            ),
+        );
+
+        Td::tag()->tabIndex(-2);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingTranslate(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::TRANSLATE->value,
+                implode("', '", Enum::normalizeArray(Translate::cases())),
+            ),
+        );
+
+        Td::tag()->translate('invalid-value');
+    }
+}

--- a/tests/Table/TdTest.php
+++ b/tests/Table/TdTest.php
@@ -6,7 +6,7 @@ namespace UIAwesome\Html\Tests\Table;
 
 use InvalidArgumentException;
 use PHPForge\Support\Stub\BackedString;
-use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Html\Attribute\Values\{
     Aria,
@@ -23,6 +23,7 @@ use UIAwesome\Html\Core\Factory\SimpleFactory;
 use UIAwesome\Html\Helper\Enum;
 use UIAwesome\Html\Helper\Exception\Message;
 use UIAwesome\Html\Table\Td;
+use UIAwesome\Html\Tests\Provider\Table\TdProvider;
 use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
 
 /**
@@ -31,7 +32,8 @@ use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
  * Test coverage.
  * - Applies global and custom attributes, including `aria-*`, `data-*` and enum-backed values.
  * - Applies table cell specific attributes (`colspan`, `headers`, `rowspan`) and renders expected output.
- * - Covers `colspan` and `rowspan` boundary values for minimum and maximum valid limits.
+ * - Covers `colspan` and `rowspan` boundary values for minimum and maximum valid limits with integer and
+ *   numeric-string inputs.
  * - Ensures attribute accessors return assigned values and fallback defaults.
  * - Renders content, raw HTML, begin/end usage, and string casting with expected encoding behavior.
  * - Resolves default and theme providers, including global defaults and user overrides.
@@ -247,29 +249,13 @@ final class TdTest extends TestCase
         );
     }
 
-    public function testRenderWithColspanMaxValue(): void
+    #[DataProviderExternal(TdProvider::class, 'colspanValues')]
+    public function testRenderWithColspanValues(int|string $value, string $expected): void
     {
         self::assertSame(
-            <<<HTML
-            <td colspan="1000">
-            </td>
-            HTML,
+            $expected,
             Td::tag()
-                ->colspan(1000)
-                ->render(),
-            "Failed asserting that element renders correctly with 'colspan' attribute.",
-        );
-    }
-
-    public function testRenderWithColspanMinValue(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <td colspan="1">
-            </td>
-            HTML,
-            Td::tag()
-                ->colspan(1)
+                ->colspan($value)
                 ->render(),
             "Failed asserting that element renders correctly with 'colspan' attribute.",
         );
@@ -623,29 +609,13 @@ final class TdTest extends TestCase
         );
     }
 
-    public function testRenderWithRowspanMaxValue(): void
+    #[DataProviderExternal(TdProvider::class, 'rowspanValues')]
+    public function testRenderWithRowspanValues(int|string $value, string $expected): void
     {
         self::assertSame(
-            <<<HTML
-            <td rowspan="65534">
-            </td>
-            HTML,
+            $expected,
             Td::tag()
-                ->rowspan(65534)
-                ->render(),
-            "Failed asserting that element renders correctly with 'rowspan' attribute.",
-        );
-    }
-
-    public function testRenderWithRowspanMinValue(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <td rowspan="0">
-            </td>
-            HTML,
-            Td::tag()
-                ->rowspan(0)
+                ->rowspan($value)
                 ->render(),
             "Failed asserting that element renders correctly with 'rowspan' attribute.",
         );

--- a/tests/Table/TdTest.php
+++ b/tests/Table/TdTest.php
@@ -452,11 +452,25 @@ final class TdTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <td headers="h1 h2">
+            <td headers="value1 value2">
             </td>
             HTML,
             Td::tag()
-                ->headers('h1 h2')
+                ->headers('value1 value2')
+                ->render(),
+            "Failed asserting that element renders correctly with 'headers' attribute.",
+        );
+    }
+
+    public function testRenderWithHeadersUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <td headers="value">
+            </td>
+            HTML,
+            Td::tag()
+                ->headers(BackedString::VALUE)
                 ->render(),
             "Failed asserting that element renders correctly with 'headers' attribute.",
         );


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
