### PR TITLE
feat(table): add convenience methods `row()`, `rows()` to `Thead`, `Tbody`, `Tfoot`; `cells()`, `headerCells()` to `Tr`; and extend `caption()` in `Table` to accept `Caption|string|null` for simplified table construction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Enh #76: Add `Thead` class for HTML `<thead>` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #77: Add `Col` class for HTML `<col>` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #78: Add `Colgroup` class for HTML `<colgroup>` element with attributes and rendering capabilities (@terabytesoftw)
+- Enh: Add convenience methods `row()`, `rows()` to `Thead`, `Tbody`, `Tfoot`; `cells()`, `headerCells()` to `Tr`; and extend `caption()` in `Table` to accept `Caption|string|null` for simplified table construction (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 - Enh #76: Add `Thead` class for HTML `<thead>` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #77: Add `Col` class for HTML `<col>` element with attributes and rendering capabilities (@terabytesoftw)
 - Enh #78: Add `Colgroup` class for HTML `<colgroup>` element with attributes and rendering capabilities (@terabytesoftw)
-- Enh: Add convenience methods `row()`, `rows()` to `Thead`, `Tbody`, `Tfoot`; `cells()`, `headerCells()` to `Tr`; and extend `caption()` in `Table` to accept `Caption|string|null` for simplified table construction (@terabytesoftw)
+- Enh #79: Add convenience methods `row()`, `rows()` to `Thead`, `Tbody`, `Tfoot`; `cells()`, `headerCells()` to `Tr`; and extend `caption()` in `Table` to accept `Caption|string|null` for simplified table construction (@terabytesoftw)
 
 ## 0.3.0 March 31, 2024
 

--- a/src/Table/Colgroup.php
+++ b/src/Table/Colgroup.php
@@ -13,12 +13,11 @@ use UIAwesome\Html\Table\Attribute\HasSpan;
  *
  * Usage example:
  * ```php
- * echo \UIAwesome\Html\Table\Colgroup::tag()
- *     ->col(
- *         \UIAwesome\Html\Table\Col::tag()
- *             ->class('weekdays')
- *             ->span(2)
- *      )
+ * use UIAwesome\Html\Table\{Col, Colgroup};
+ *
+ * echo Colgroup::tag()
+ *     ->col(Col::tag()->class('weekdays')->span(2))
+ *     ->col(Col::tag()->class('weekend')->span(2))
  *     ->render();
  * ```
  *
@@ -34,6 +33,13 @@ final class Colgroup extends BaseBlock
 
     /**
      * Appends a `<col>` element to the column group.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Table\Colgroup::tag()
+     *     ->col(\UIAwesome\Html\Table\Col::tag()->class('weekdays')->span(2))
+     *     ->render();
+     * ```
      *
      * @param Col $col Table column element instance.
      *

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -34,6 +34,14 @@ final class Table extends BaseBlock
      *
      * Accepts a `Caption` instance for full control, or a string that is automatically wrapped in a `Caption` element.
      *
+     * Usage examples:
+     * ```php
+     * $table = Table::tag()->caption('Monthly report');
+     * $table = Table::tag()->caption(Caption::tag()->content('Monthly report'));
+     * $table = Table::tag()->caption(null);
+     * ```
+     *
+     *
      * @param Caption|string|null $caption Caption instance, string content, or `null` to skip.
      *
      * @return static New instance with the appended table caption.
@@ -54,6 +62,11 @@ final class Table extends BaseBlock
     /**
      * Appends a `<colgroup>` element to the table.
      *
+     * Usage example:
+     * ```php
+     * $table = Table::tag()->colgroup(Colgroup::tag()->col()->col());
+     * ```
+     *
      * @param Colgroup $colgroup Table column group element instance.
      *
      * @return static New instance with the appended table column group.
@@ -65,6 +78,11 @@ final class Table extends BaseBlock
 
     /**
      * Appends a `<tbody>` element to the table.
+     *
+     * Usage example:
+     * ```php
+     * $table = Table::tag()->tbody(Tbody::tag()->row('Jane', '30'));
+     * ```
      *
      * @param Tbody $tbody Table body element instance.
      *
@@ -78,6 +96,11 @@ final class Table extends BaseBlock
     /**
      * Appends a `<tfoot>` element to the table.
      *
+     * Usage example:
+     * ```php
+     * $table = Table::tag()->tfoot(Tfoot::tag()->row('Totals', '100'));
+     * ```
+     *
      * @param Tfoot $tfoot Table footer element instance.
      *
      * @return static New instance with the appended table footer.
@@ -90,6 +113,11 @@ final class Table extends BaseBlock
     /**
      * Appends a `<thead>` element to the table.
      *
+     * Usage example:
+     * ```php
+     * $table = Table::tag()->thead(Thead::tag()->row('Name', 'Age'));
+     * ```
+     *
      * @param Thead $thead Table head element instance.
      *
      * @return static New instance with the appended table head.
@@ -101,6 +129,11 @@ final class Table extends BaseBlock
 
     /**
      * Appends a `<tr>` element directly to the table.
+     *
+     * Usage example:
+     * ```php
+     * $table = Table::tag()->tr(Tr::tag()->cells('Jane', '30'));
+     * ```
      *
      * @param Tr $tr Table row element instance.
      *

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -7,6 +7,8 @@ namespace UIAwesome\Html\Table;
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\Table as TableTag;
 
+use function is_string;
+
 /**
  * Renders the HTML `<table>` element for tabular data.
  *

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -41,7 +41,6 @@ final class Table extends BaseBlock
      * $table = Table::tag()->caption(null);
      * ```
      *
-     *
      * @param Caption|string|null $caption Caption instance, string content, or `null` to skip.
      *
      * @return static New instance with the appended table caption.

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Table;
+
+use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Interop\Table as TableTag;
+
+/**
+ * Renders the HTML `<table>` element for tabular data.
+ *
+ * Usage example:
+ * ```php
+ * use UIAwesome\Html\Table\{Table, Tbody, Thead};
+ *
+ * echo Table::tag()
+ *     ->caption('Monthly report')
+ *     ->thead(Thead::tag()->row('Name', 'Age'))
+ *     ->tbody(Tbody::tag()->row('Jane', '30'))
+ *     ->render();
+ * ```
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table
+ * {@see BaseBlock} for the base implementation.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class Table extends BaseBlock
+{
+    /**
+     * Appends a `<caption>` element to the table.
+     *
+     * Accepts a `Caption` instance for full control, or a string that is automatically wrapped in a `Caption` element.
+     *
+     * @param Caption|string|null $caption Caption instance, string content, or `null` to skip.
+     *
+     * @return static New instance with the appended table caption.
+     */
+    public function caption(Caption|string|null $caption): static
+    {
+        if ($caption === null) {
+            return $this;
+        }
+
+        if (is_string($caption)) {
+            $caption = Caption::tag()->content($caption);
+        }
+
+        return $this->html($caption, "\n");
+    }
+
+    /**
+     * Appends a `<colgroup>` element to the table.
+     *
+     * @param Colgroup $colgroup Table column group element instance.
+     *
+     * @return static New instance with the appended table column group.
+     */
+    public function colgroup(Colgroup $colgroup): static
+    {
+        return $this->html($colgroup, "\n");
+    }
+
+    /**
+     * Appends a `<tbody>` element to the table.
+     *
+     * @param Tbody $tbody Table body element instance.
+     *
+     * @return static New instance with the appended table body.
+     */
+    public function tbody(Tbody $tbody): static
+    {
+        return $this->html($tbody, "\n");
+    }
+
+    /**
+     * Appends a `<tfoot>` element to the table.
+     *
+     * @param Tfoot $tfoot Table footer element instance.
+     *
+     * @return static New instance with the appended table footer.
+     */
+    public function tfoot(Tfoot $tfoot): static
+    {
+        return $this->html($tfoot, "\n");
+    }
+
+    /**
+     * Appends a `<thead>` element to the table.
+     *
+     * @param Thead $thead Table head element instance.
+     *
+     * @return static New instance with the appended table head.
+     */
+    public function thead(Thead $thead): static
+    {
+        return $this->html($thead, "\n");
+    }
+
+    /**
+     * Appends a `<tr>` element directly to the table.
+     *
+     * @param Tr $tr Table row element instance.
+     *
+     * @return static New instance with the appended table row.
+     */
+    public function tr(Tr $tr): static
+    {
+        return $this->html($tr, "\n");
+    }
+
+    /**
+     * Returns the tag enumeration for the `<table>` element.
+     *
+     * @return TableTag Tag enumeration instance for `<table>`.
+     *
+     * {@see TableTag} for valid table tags.
+     */
+    protected function getTag(): TableTag
+    {
+        return TableTag::TABLE;
+    }
+}

--- a/src/Table/Tbody.php
+++ b/src/Table/Tbody.php
@@ -66,7 +66,7 @@ final class Tbody extends BaseBlock
         $tbody = $this;
 
         foreach ($rows as $row) {
-            $tbody = $tbody->row(...array_values($row));
+            $tbody = $tbody->row(...$row);
         }
 
         return $tbody;

--- a/src/Table/Tbody.php
+++ b/src/Table/Tbody.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Table;
 
+use Stringable;
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\Table;
 
@@ -29,6 +30,46 @@ use UIAwesome\Html\Interop\Table;
  */
 final class Tbody extends BaseBlock
 {
+    /**
+     * Appends a `<tr>` element with `<td>` cells for each value.
+     *
+     * Usage example:
+     * ```php
+     * $tbody = \UIAwesome\Html\Table\Tbody::tag()->row('Jane', '30', 'NYC');
+     * ```
+     *
+     * @param string|Stringable ...$cells Content for each `<td>` cell.
+     *
+     * @return static New instance with the appended data row.
+     */
+    public function row(string|Stringable ...$cells): static
+    {
+        return $this->tr(Tr::tag()->cells(...$cells));
+    }
+
+    /**
+     * Appends multiple `<tr>` elements with `<td>` cells.
+     *
+     * Usage example:
+     * ```php
+     * $tbody = \UIAwesome\Html\Table\Tbody::tag()->rows(['Jane', '30'], ['John', '25']);
+     * ```
+     *
+     * @param array<int, string|Stringable> ...$rows Arrays of cell content for each row.
+     *
+     * @return static New instance with the appended data rows.
+     */
+    public function rows(array ...$rows): static
+    {
+        $tbody = $this;
+
+        foreach ($rows as $row) {
+            $tbody = $tbody->row(...$row);
+        }
+
+        return $tbody;
+    }
+
     /**
      * Appends a `<tr>` element to the table body.
      *

--- a/src/Table/Tbody.php
+++ b/src/Table/Tbody.php
@@ -13,11 +13,13 @@ use UIAwesome\Html\Interop\Table;
  *
  * Usage example:
  * ```php
- * echo \UIAwesome\Html\Table\Tbody::tag()
+ * use UIAwesome\Html\Table\{Tbody, Td, Tr};
+ *
+ * echo Tbody::tag()
  *     ->tr(
- *         \UIAwesome\Html\Table\Tr::tag()
- *             ->td(\UIAwesome\Html\Table\Td::tag()->content('Jane'))
- *             ->td(\UIAwesome\Html\Table\Td::tag()->content('Engineering'))
+ *         Tr::tag()
+ *             ->td(Td::tag()->content('Jane'))
+ *             ->td(Td::tag()->content('Engineering'))
  *     )
  *     ->render();
  * ```
@@ -55,7 +57,7 @@ final class Tbody extends BaseBlock
      * $tbody = \UIAwesome\Html\Table\Tbody::tag()->rows(['Jane', '30'], ['John', '25']);
      * ```
      *
-     * @param array<int, string|Stringable> ...$rows Arrays of cell content for each row.
+     * @param array<array-key, string|Stringable> ...$rows Arrays of cell content for each row.
      *
      * @return static New instance with the appended data rows.
      */
@@ -72,6 +74,12 @@ final class Tbody extends BaseBlock
 
     /**
      * Appends a `<tr>` element to the table body.
+     *
+     * Usage example:
+     * ```php
+     * $tr = \UIAwesome\Html\Table\Tr::tag()->td('Jane')->td('30');
+     * $tbody = \UIAwesome\Html\Table\Tbody::tag()->tr($tr);
+     * ```
      *
      * @param Tr $tr Table row element instance.
      *

--- a/src/Table/Tbody.php
+++ b/src/Table/Tbody.php
@@ -64,7 +64,7 @@ final class Tbody extends BaseBlock
         $tbody = $this;
 
         foreach ($rows as $row) {
-            $tbody = $tbody->row(...$row);
+            $tbody = $tbody->row(...array_values($row));
         }
 
         return $tbody;

--- a/src/Table/Tbody.php
+++ b/src/Table/Tbody.php
@@ -77,7 +77,7 @@ final class Tbody extends BaseBlock
      *
      * Usage example:
      * ```php
-     * $tr = \UIAwesome\Html\Table\Tr::tag()->td('Jane')->td('30');
+     * $tr = \UIAwesome\Html\Table\Tr::tag()->td(Td::tag()->content('Jane'));
      * $tbody = \UIAwesome\Html\Table\Tbody::tag()->tr($tr);
      * ```
      *

--- a/src/Table/Tfoot.php
+++ b/src/Table/Tfoot.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Table;
 
+use Stringable;
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\Table;
 
@@ -27,6 +28,46 @@ use UIAwesome\Html\Interop\Table;
  */
 final class Tfoot extends BaseBlock
 {
+    /**
+     * Appends a `<tr>` element with `<td>` cells for each value.
+     *
+     * Usage example:
+     * ```php
+     * $tfoot = \UIAwesome\Html\Table\Tfoot::tag()->row('Totals', '100');
+     * ```
+     *
+     * @param string|Stringable ...$cells Content for each `<td>` cell.
+     *
+     * @return static New instance with the appended footer row.
+     */
+    public function row(string|Stringable ...$cells): static
+    {
+        return $this->tr(Tr::tag()->cells(...$cells));
+    }
+
+    /**
+     * Appends multiple `<tr>` elements with `<td>` cells.
+     *
+     * Usage example:
+     * ```php
+     * $tfoot = \UIAwesome\Html\Table\Tfoot::tag()->rows(['Subtotal', '80'], ['Total', '100']);
+     * ```
+     *
+     * @param array<int, string|Stringable> ...$rows Arrays of cell content for each row.
+     *
+     * @return static New instance with the appended footer rows.
+     */
+    public function rows(array ...$rows): static
+    {
+        $tfoot = $this;
+
+        foreach ($rows as $row) {
+            $tfoot = $tfoot->row(...$row);
+        }
+
+        return $tfoot;
+    }
+
     /**
      * Appends a `<tr>` element to the table footer.
      *

--- a/src/Table/Tfoot.php
+++ b/src/Table/Tfoot.php
@@ -63,7 +63,7 @@ final class Tfoot extends BaseBlock
         $tfoot = $this;
 
         foreach ($rows as $row) {
-            $tfoot = $tfoot->row(...array_values($row));
+            $tfoot = $tfoot->row(...$row);
         }
 
         return $tfoot;

--- a/src/Table/Tfoot.php
+++ b/src/Table/Tfoot.php
@@ -62,7 +62,7 @@ final class Tfoot extends BaseBlock
         $tfoot = $this;
 
         foreach ($rows as $row) {
-            $tfoot = $tfoot->row(...$row);
+            $tfoot = $tfoot->row(...array_values($row));
         }
 
         return $tfoot;

--- a/src/Table/Tfoot.php
+++ b/src/Table/Tfoot.php
@@ -13,10 +13,11 @@ use UIAwesome\Html\Interop\Table;
  *
  * Usage example:
  * ```php
- * echo \UIAwesome\Html\Table\Tfoot::tag()
- *     ->tr(
- *         \UIAwesome\Html\Table\Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('Totals'))
- *     )
+ * use UIAwesome\Html\Table\{Td, Tfoot, Tr};
+ *
+ * echo Tfoot::tag()
+ *     ->tr(Tr::tag()->td(Td::tag()->content('Totals')))
+ *     ->tr(Tr::tag()->td(Td::tag()->content('100')))
  *     ->render();
  * ```
  *
@@ -53,7 +54,7 @@ final class Tfoot extends BaseBlock
      * $tfoot = \UIAwesome\Html\Table\Tfoot::tag()->rows(['Subtotal', '80'], ['Total', '100']);
      * ```
      *
-     * @param array<int, string|Stringable> ...$rows Arrays of cell content for each row.
+     * @param array<array-key, string|Stringable> ...$rows Arrays of cell content for each row.
      *
      * @return static New instance with the appended footer rows.
      */
@@ -70,6 +71,13 @@ final class Tfoot extends BaseBlock
 
     /**
      * Appends a `<tr>` element to the table footer.
+     *
+     * Usage example:
+     * ```php
+     * echo \UIAwesome\Html\Table\Tfoot::tag()
+     *     ->tr(Tr::tag()->td(Td::tag()->content('Totals')))
+     *     ->render();
+     * ```
      *
      * @param Tr $tr Table row element instance.
      *

--- a/src/Table/Thead.php
+++ b/src/Table/Thead.php
@@ -64,7 +64,7 @@ final class Thead extends BaseBlock
         $thead = $this;
 
         foreach ($rows as $row) {
-            $thead = $thead->row(...$row);
+            $thead = $thead->row(...array_values($row));
         }
 
         return $thead;

--- a/src/Table/Thead.php
+++ b/src/Table/Thead.php
@@ -62,7 +62,7 @@ final class Thead extends BaseBlock
         $thead = $this;
 
         foreach ($rows as $row) {
-            $thead = $thead->row(...array_values($row));
+            $thead = $thead->row(...$row);
         }
 
         return $thead;

--- a/src/Table/Thead.php
+++ b/src/Table/Thead.php
@@ -13,12 +13,10 @@ use UIAwesome\Html\Interop\Table;
  *
  * Usage example:
  * ```php
- * echo \UIAwesome\Html\Table\Thead::tag()
- *     ->tr(
- *         \UIAwesome\Html\Table\Tr::tag()->th(
- *             \UIAwesome\Html\Table\Th::tag()->content('Name')
- *         )
- *     )
+ * use UIAwesome\Html\Table\{Th, Thead, Tr};
+ *
+ * echo Thead::tag()
+ *     ->tr(Tr::tag()->th(Th::tag()->content('Name')))
  *     ->render();
  * ```
  *
@@ -55,7 +53,7 @@ final class Thead extends BaseBlock
      * $thead = \UIAwesome\Html\Table\Thead::tag()->rows(['Name', 'Age'], ['ID', 'Email']);
      * ```
      *
-     * @param array<int, string|Stringable> ...$rows Arrays of cell content for each row.
+     * @param array<array-key, string|Stringable> ...$rows Arrays of cell content for each row.
      *
      * @return static New instance with the appended header rows.
      */
@@ -72,6 +70,12 @@ final class Thead extends BaseBlock
 
     /**
      * Appends a `<tr>` element to the table header.
+     *
+     * Usage example:
+     * ```php
+     * $tr = \UIAwesome\Html\Table\Tr::tag()->th(Th::tag()->content('Name'));
+     * $thead = \UIAwesome\Html\Table\Thead::tag()->tr($tr);
+     * ```
      *
      * @param Tr $tr Table row element instance.
      *

--- a/src/Table/Thead.php
+++ b/src/Table/Thead.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Table;
 
+use Stringable;
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\Table;
 
@@ -29,6 +30,46 @@ use UIAwesome\Html\Interop\Table;
  */
 final class Thead extends BaseBlock
 {
+    /**
+     * Appends a `<tr>` element with `<th>` cells for each value.
+     *
+     * Usage example:
+     * ```php
+     * $thead = \UIAwesome\Html\Table\Thead::tag()->row('Name', 'Age', 'City');
+     * ```
+     *
+     * @param string|Stringable ...$cells Content for each `<th>` cell.
+     *
+     * @return static New instance with the appended header row.
+     */
+    public function row(string|Stringable ...$cells): static
+    {
+        return $this->tr(Tr::tag()->headerCells(...$cells));
+    }
+
+    /**
+     * Appends multiple `<tr>` elements with `<th>` cells.
+     *
+     * Usage example:
+     * ```php
+     * $thead = \UIAwesome\Html\Table\Thead::tag()->rows(['Name', 'Age'], ['ID', 'Email']);
+     * ```
+     *
+     * @param array<int, string|Stringable> ...$rows Arrays of cell content for each row.
+     *
+     * @return static New instance with the appended header rows.
+     */
+    public function rows(array ...$rows): static
+    {
+        $thead = $this;
+
+        foreach ($rows as $row) {
+            $thead = $thead->row(...$row);
+        }
+
+        return $thead;
+    }
+
     /**
      * Appends a `<tr>` element to the table header.
      *

--- a/src/Table/Tr.php
+++ b/src/Table/Tr.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Table;
 
+use Stringable;
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Interop\Table;
 
@@ -26,6 +27,52 @@ use UIAwesome\Html\Interop\Table;
  */
 final class Tr extends BaseBlock
 {
+    /**
+     * Appends `<td>` elements for each value.
+     *
+     * Usage example:
+     * ```php
+     * $tr = \UIAwesome\Html\Table\Tr::tag()->cells('Jane', '30', 'NYC');
+     * ```
+     *
+     * @param string|Stringable ...$values Content for each `<td>` cell.
+     *
+     * @return static New instance with the appended data cells.
+     */
+    public function cells(string|Stringable ...$values): static
+    {
+        $tr = $this;
+
+        foreach ($values as $value) {
+            $tr = $tr->td(Td::tag()->content($value));
+        }
+
+        return $tr;
+    }
+
+    /**
+     * Appends `<th>` elements for each value.
+     *
+     * Usage example:
+     * ```php
+     * $tr = \UIAwesome\Html\Table\Tr::tag()->headerCells('Name', 'Age', 'City');
+     * ```
+     *
+     * @param string|Stringable ...$values Content for each `<th>` cell.
+     *
+     * @return static New instance with the appended header cells.
+     */
+    public function headerCells(string|Stringable ...$values): static
+    {
+        $tr = $this;
+
+        foreach ($values as $value) {
+            $tr = $tr->th(Th::tag()->content($value));
+        }
+
+        return $tr;
+    }
+
     /**
      * Appends a `<td>` element to the row.
      *

--- a/src/Table/Tr.php
+++ b/src/Table/Tr.php
@@ -13,9 +13,11 @@ use UIAwesome\Html\Interop\Table;
  *
  * Usage example:
  * ```php
- * echo \UIAwesome\Html\Table\Tr::tag()
- *     ->th(\UIAwesome\Html\Table\Th::tag()->content('Name'))
- *     ->td(\UIAwesome\Html\Table\Td::tag()->content('Jane'))
+ * use UIAwesome\Html\Table\{Td, Th, Tr};
+ *
+ * echo Tr::tag()
+ *     ->th(Th::tag()->content('Name'))
+ *     ->td(Td::tag()->content('Jane'))
  *     ->render();
  * ```
  *
@@ -76,6 +78,11 @@ final class Tr extends BaseBlock
     /**
      * Appends a `<td>` element to the row.
      *
+     * Usage example:
+     * ```php
+     * $tr = \UIAwesome\Html\Table\Tr::tag()->td(Td::tag()->content('Jane'));
+     * ```
+     *
      * @param Td $td Table data cell element instance.
      *
      * @return static New instance with the appended table data cell.
@@ -87,6 +94,11 @@ final class Tr extends BaseBlock
 
     /**
      * Appends a `<th>` element to the row.
+     *
+     * Usage example:
+     * ```php
+     * $tr = \UIAwesome\Html\Table\Tr::tag()->th(Th::tag()->content('Name'));
+     * ```
      *
      * @param Th $th Table header cell element instance.
      *

--- a/tests/Table/TableTest.php
+++ b/tests/Table/TableTest.php
@@ -22,7 +22,7 @@ use UIAwesome\Html\Attribute\Values\{
 use UIAwesome\Html\Core\Factory\SimpleFactory;
 use UIAwesome\Html\Helper\Enum;
 use UIAwesome\Html\Helper\Exception\Message;
-use UIAwesome\Html\Table\{Caption, Col, Colgroup, Table, Tbody, Tfoot, Thead, Tr};
+use UIAwesome\Html\Table\{Caption, Col, Colgroup, Table, Tbody, Td, Tfoot, Th, Thead, Tr};
 use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
 
 /**
@@ -517,9 +517,9 @@ final class TableTest extends TestCase
             Table::tag()
                 ->caption(Caption::tag()->content('Members'))
                 ->colgroup(Colgroup::tag()->col(Col::tag()->span(2)))
-                ->thead(Thead::tag()->tr(Tr::tag()->th(\UIAwesome\Html\Table\Th::tag()->content('Name'))))
-                ->tbody(Tbody::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('Jane'))))
-                ->tfoot(Tfoot::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('Total'))))
+                ->thead(Thead::tag()->tr(Tr::tag()->th(Th::tag()->content('Name'))))
+                ->tbody(Tbody::tag()->tr(Tr::tag()->td(Td::tag()->content('Jane'))))
+                ->tfoot(Tfoot::tag()->tr(Tr::tag()->td(Td::tag()->content('Total'))))
                 ->render(),
             'Failed asserting that complete table widgets compose correctly into the final HTML.',
         );
@@ -829,7 +829,7 @@ final class TableTest extends TestCase
             </table>
             HTML,
             Table::tag()
-                ->tbody(Tbody::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('value'))))
+                ->tbody(Tbody::tag()->tr(Tr::tag()->td(Td::tag()->content('value'))))
                 ->render(),
             "Failed asserting that element renders correctly with 'tbody()' method.",
         );
@@ -850,7 +850,7 @@ final class TableTest extends TestCase
             </table>
             HTML,
             Table::tag()
-                ->tfoot(Tfoot::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('value'))))
+                ->tfoot(Tfoot::tag()->tr(Tr::tag()->td(Td::tag()->content('value'))))
                 ->render(),
             "Failed asserting that element renders correctly with 'tfoot()' method.",
         );
@@ -871,7 +871,7 @@ final class TableTest extends TestCase
             </table>
             HTML,
             Table::tag()
-                ->thead(Thead::tag()->tr(Tr::tag()->th(\UIAwesome\Html\Table\Th::tag()->content('value'))))
+                ->thead(Thead::tag()->tr(Tr::tag()->th(Th::tag()->content('value'))))
                 ->render(),
             "Failed asserting that element renders correctly with 'thead()' method.",
         );
@@ -930,7 +930,7 @@ final class TableTest extends TestCase
             </table>
             HTML,
             Table::tag()
-                ->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('value')))
+                ->tr(Tr::tag()->td(Td::tag()->content('value')))
                 ->render(),
             "Failed asserting that element renders correctly with 'tr()' method.",
         );

--- a/tests/Table/TableTest.php
+++ b/tests/Table/TableTest.php
@@ -267,6 +267,23 @@ final class TableTest extends TestCase
         );
     }
 
+    public function testRenderWithCaptionStringEscapesHtml(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <table>
+            <caption>
+            &lt;em&gt;Members&lt;/em&gt;
+            </caption>
+            </table>
+            HTML,
+            Table::tag()
+                ->caption('<em>Members</em>')
+                ->render(),
+            "Failed asserting that 'caption()' method escapes HTML when using string.",
+        );
+    }
+
     public function testRenderWithClass(): void
     {
         self::assertSame(
@@ -463,6 +480,51 @@ final class TableTest extends TestCase
         );
     }
 
+    public function testRenderWithFullTableStructure(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <table>
+            <caption>
+            Members
+            </caption>
+            <colgroup>
+            <col span="2">
+            </colgroup>
+            <thead>
+            <tr>
+            <th>
+            Name
+            </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+            <td>
+            Jane
+            </td>
+            </tr>
+            </tbody>
+            <tfoot>
+            <tr>
+            <td>
+            Total
+            </td>
+            </tr>
+            </tfoot>
+            </table>
+            HTML,
+            Table::tag()
+                ->caption(Caption::tag()->content('Members'))
+                ->colgroup(Colgroup::tag()->col(Col::tag()->span(2)))
+                ->thead(Thead::tag()->tr(Tr::tag()->th(\UIAwesome\Html\Table\Th::tag()->content('Name'))))
+                ->tbody(Tbody::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('Jane'))))
+                ->tfoot(Tfoot::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('Total'))))
+                ->render(),
+            'Failed asserting that complete table widgets compose correctly into the final HTML.',
+        );
+    }
+
     public function testRenderWithFullTableStructureUsingConvenienceMethods(): void
     {
         self::assertSame(
@@ -510,51 +572,6 @@ final class TableTest extends TestCase
                 ->tfoot(Tfoot::tag()->row('Total', '1'))
                 ->render(),
             'Failed asserting that complete table composes correctly using convenience methods.',
-        );
-    }
-
-    public function testRenderWithFullTableStructure(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <table>
-            <caption>
-            Members
-            </caption>
-            <colgroup>
-            <col span="2">
-            </colgroup>
-            <thead>
-            <tr>
-            <th>
-            Name
-            </th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-            <td>
-            Jane
-            </td>
-            </tr>
-            </tbody>
-            <tfoot>
-            <tr>
-            <td>
-            Total
-            </td>
-            </tr>
-            </tfoot>
-            </table>
-            HTML,
-            Table::tag()
-                ->caption(Caption::tag()->content('Members'))
-                ->colgroup(Colgroup::tag()->col(Col::tag()->span(2)))
-                ->thead(Thead::tag()->tr(Tr::tag()->th(\UIAwesome\Html\Table\Th::tag()->content('Name'))))
-                ->tbody(Tbody::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('Jane'))))
-                ->tfoot(Tfoot::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('Total'))))
-                ->render(),
-            'Failed asserting that complete table widgets compose correctly into the final HTML.',
         );
     }
 

--- a/tests/Table/TableTest.php
+++ b/tests/Table/TableTest.php
@@ -22,15 +22,16 @@ use UIAwesome\Html\Attribute\Values\{
 use UIAwesome\Html\Core\Factory\SimpleFactory;
 use UIAwesome\Html\Helper\Enum;
 use UIAwesome\Html\Helper\Exception\Message;
-use UIAwesome\Html\Table\{Td, Th, Tr};
+use UIAwesome\Html\Table\{Caption, Col, Colgroup, Table, Tbody, Tfoot, Thead, Tr};
 use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
 
 /**
- * Unit tests for {@see Tr} rendering and row composition behavior.
+ * Unit tests for {@see Table} rendering and table structure composition behavior.
  *
  * Test coverage.
- * - Appends table row cells using `td()`, `th()`, `cells()`, and `headerCells()` and renders expected output.
+ * - Appends table child elements using `caption()`, `colgroup()`, `thead()`, `tbody()`, `tr()`, and `tfoot()`.
  * - Applies global and custom attributes, including `aria-*`, `data-*` and enum-backed values.
+ * - Composes a full table structure using convenience methods (`caption()` with string, `row()`, `rows()`).
  * - Ensures attribute accessors return assigned values and fallback defaults.
  * - Renders content, raw HTML, begin/end usage, and string casting with expected encoding behavior.
  * - Resolves default and theme providers, including global defaults and user overrides.
@@ -40,13 +41,13 @@ use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
 #[Group('table')]
-final class TrTest extends TestCase
+final class TableTest extends TestCase
 {
     public function testContentEncodesValues(): void
     {
         self::assertSame(
             '&lt;value&gt;',
-            Tr::tag()
+            Table::tag()
                 ->content('<value>')
                 ->getContent(),
             "Failed asserting that 'content()' method encodes values correctly.",
@@ -57,7 +58,7 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             'value',
-            Tr::tag()->getAttribute('class', 'value'),
+            Table::tag()->getAttribute('class', 'value'),
             "Failed asserting that 'getAttribute()' returns the default value when missing.",
         );
     }
@@ -66,7 +67,7 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             ['class' => 'value'],
-            Tr::tag()
+            Table::tag()
                 ->setAttribute('class', 'value')
                 ->getAttributes(),
             "Failed asserting that 'getAttributes()' returns the assigned attributes.",
@@ -77,11 +78,11 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr>
+            <table>
             <value>
-            </tr>
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->html('<value>')
                 ->render(),
             "Failed asserting that element renders correctly with 'html()' method.",
@@ -92,10 +93,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr accesskey="value">
-            </tr>
+            <table accesskey="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->accesskey('value')
                 ->render(),
             "Failed asserting that element renders correctly with 'accesskey' attribute.",
@@ -106,10 +107,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr aria-label="value">
-            </tr>
+            <table aria-label="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->addAriaAttribute('label', 'value')
                 ->render(),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
@@ -120,10 +121,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr aria-label="value">
-            </tr>
+            <table aria-label="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->addAriaAttribute(Aria::LABEL, 'value')
                 ->render(),
             "Failed asserting that element renders correctly with 'addAriaAttribute()' method.",
@@ -134,10 +135,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr data-value="value">
-            </tr>
+            <table data-value="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->addDataAttribute('value', 'value')
                 ->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
@@ -148,10 +149,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr data-value="value">
-            </tr>
+            <table data-value="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->addDataAttribute(Data::VALUE, 'value')
                 ->render(),
             "Failed asserting that element renders correctly with 'addDataAttribute()' method.",
@@ -162,10 +163,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr aria-controls="value" aria-label="value">
-            </tr>
+            <table aria-controls="value" aria-label="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->ariaAttributes(
                     [
                         'controls' => 'value',
@@ -181,10 +182,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr class="value">
-            </tr>
+            <table class="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->attributes(['class' => 'value'])
                 ->render(),
             "Failed asserting that element renders correctly with 'attributes()' method.",
@@ -195,10 +196,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr autofocus>
-            </tr>
+            <table autofocus>
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->autofocus(true)
                 ->render(),
             "Failed asserting that element renders correctly with 'autofocus' attribute.",
@@ -209,12 +210,60 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr>
+            <table>
             Content
-            </tr>
+            </table>
             HTML,
-            Tr::tag()->begin() . 'Content' . Tr::end(),
+            Table::tag()->begin() . 'Content' . Table::end(),
             "Failed asserting that element renders correctly with 'begin()' and 'end()' methods.",
+        );
+    }
+
+    public function testRenderWithCaption(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <table>
+            <caption>
+            value
+            </caption>
+            </table>
+            HTML,
+            Table::tag()
+                ->caption(Caption::tag()->content('value'))
+                ->render(),
+            "Failed asserting that element renders correctly with 'caption()' method using Caption instance.",
+        );
+    }
+
+    public function testRenderWithCaptionNull(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <table>
+            </table>
+            HTML,
+            Table::tag()
+                ->caption(null)
+                ->render(),
+            "Failed asserting that element renders correctly with 'caption()' method using `null`.",
+        );
+    }
+
+    public function testRenderWithCaptionString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <table>
+            <caption>
+            Monthly report
+            </caption>
+            </table>
+            HTML,
+            Table::tag()
+                ->caption('Monthly report')
+                ->render(),
+            "Failed asserting that element renders correctly with 'caption()' method using string.",
         );
     }
 
@@ -222,10 +271,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr class="value">
-            </tr>
+            <table class="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->class('value')
                 ->render(),
             "Failed asserting that element renders correctly with 'class' attribute.",
@@ -236,13 +285,30 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr class="value">
-            </tr>
+            <table class="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->class(BackedString::VALUE)
                 ->render(),
             "Failed asserting that element renders correctly with 'class' attribute.",
+        );
+    }
+
+    public function testRenderWithColgroup(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <table>
+            <colgroup>
+            <col span="2">
+            </colgroup>
+            </table>
+            HTML,
+            Table::tag()
+                ->colgroup(Colgroup::tag()->col(Col::tag()->span(2)))
+                ->render(),
+            "Failed asserting that element renders correctly with 'colgroup()' method.",
         );
     }
 
@@ -250,11 +316,11 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr>
+            <table>
             value
-            </tr>
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->content('value')
                 ->render(),
             'Failed asserting that element renders correctly with default values.',
@@ -265,10 +331,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr contenteditable="true">
-            </tr>
+            <table contenteditable="true">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->contentEditable(true)
                 ->render(),
             "Failed asserting that element renders correctly with 'contentEditable' attribute.",
@@ -279,10 +345,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr contenteditable="true">
-            </tr>
+            <table contenteditable="true">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->contentEditable(ContentEditable::TRUE)
                 ->render(),
             "Failed asserting that element renders correctly with 'contentEditable' attribute.",
@@ -293,10 +359,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr data-value="value">
-            </tr>
+            <table data-value="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->dataAttributes(['value' => 'value'])
                 ->render(),
             "Failed asserting that element renders correctly with 'dataAttributes()' method.",
@@ -307,10 +373,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr class="default-class">
-            </tr>
+            <table class="default-class">
+            </table>
             HTML,
-            Tr::tag(['class' => 'default-class'])->render(),
+            Table::tag(['class' => 'default-class'])->render(),
             'Failed asserting that default configuration values are applied correctly.',
         );
     }
@@ -319,10 +385,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr class="default-class">
-            </tr>
+            <table class="default-class">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->addDefaultProvider(DefaultProvider::class)
                 ->render(),
             'Failed asserting that default provider is applied correctly.',
@@ -333,10 +399,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr>
-            </tr>
+            <table>
+            </table>
             HTML,
-            Tr::tag()->render(),
+            Table::tag()->render(),
             'Failed asserting that element renders correctly with default values.',
         );
     }
@@ -345,10 +411,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr dir="ltr">
-            </tr>
+            <table dir="ltr">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->dir('ltr')
                 ->render(),
             "Failed asserting that element renders correctly with 'dir' attribute.",
@@ -359,10 +425,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr dir="ltr">
-            </tr>
+            <table dir="ltr">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->dir(Direction::LTR)
                 ->render(),
             "Failed asserting that element renders correctly with 'dir' attribute.",
@@ -373,10 +439,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr draggable="true">
-            </tr>
+            <table draggable="true">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->draggable(true)
                 ->render(),
             "Failed asserting that element renders correctly with 'draggable' attribute.",
@@ -387,34 +453,129 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr draggable="true">
-            </tr>
+            <table draggable="true">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->draggable(Draggable::TRUE)
                 ->render(),
             "Failed asserting that element renders correctly with 'draggable' attribute.",
         );
     }
 
+    public function testRenderWithFullTableStructureUsingConvenienceMethods(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <table>
+            <caption>
+            Members
+            </caption>
+            <thead>
+            <tr>
+            <th>
+            Name
+            </th>
+            <th>
+            Age
+            </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+            <td>
+            Jane
+            </td>
+            <td>
+            30
+            </td>
+            </tr>
+            </tbody>
+            <tfoot>
+            <tr>
+            <td>
+            Total
+            </td>
+            <td>
+            1
+            </td>
+            </tr>
+            </tfoot>
+            </table>
+            HTML,
+            Table::tag()
+                ->caption('Members')
+                ->thead(Thead::tag()->row('Name', 'Age'))
+                ->tbody(Tbody::tag()->row('Jane', '30'))
+                ->tfoot(Tfoot::tag()->row('Total', '1'))
+                ->render(),
+            'Failed asserting that complete table composes correctly using convenience methods.',
+        );
+    }
+
+    public function testRenderWithFullTableStructure(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <table>
+            <caption>
+            Members
+            </caption>
+            <colgroup>
+            <col span="2">
+            </colgroup>
+            <thead>
+            <tr>
+            <th>
+            Name
+            </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+            <td>
+            Jane
+            </td>
+            </tr>
+            </tbody>
+            <tfoot>
+            <tr>
+            <td>
+            Total
+            </td>
+            </tr>
+            </tfoot>
+            </table>
+            HTML,
+            Table::tag()
+                ->caption(Caption::tag()->content('Members'))
+                ->colgroup(Colgroup::tag()->col(Col::tag()->span(2)))
+                ->thead(Thead::tag()->tr(Tr::tag()->th(\UIAwesome\Html\Table\Th::tag()->content('Name'))))
+                ->tbody(Tbody::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('Jane'))))
+                ->tfoot(Tfoot::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('Total'))))
+                ->render(),
+            'Failed asserting that complete table widgets compose correctly into the final HTML.',
+        );
+    }
+
     public function testRenderWithGlobalDefaultsAreApplied(): void
     {
         SimpleFactory::setDefaults(
-            Tr::class,
+            Table::class,
             ['class' => 'default-class'],
         );
 
         self::assertSame(
             <<<HTML
-            <tr class="default-class">
-            </tr>
+            <table class="default-class">
+            </table>
             HTML,
-            Tr::tag()->render(),
+            Table::tag()->render(),
             'Failed asserting that global defaults are applied correctly.',
         );
 
         SimpleFactory::setDefaults(
-            Tr::class,
+            Table::class,
             [],
         );
     }
@@ -423,10 +584,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr hidden>
-            </tr>
+            <table hidden>
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->hidden(true)
                 ->render(),
             "Failed asserting that element renders correctly with 'hidden' attribute.",
@@ -437,10 +598,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr id="value">
-            </tr>
+            <table id="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->id('value')
                 ->render(),
             "Failed asserting that element renders correctly with 'id' attribute.",
@@ -451,10 +612,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr lang="en">
-            </tr>
+            <table lang="en">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->lang('en')
                 ->render(),
             "Failed asserting that element renders correctly with 'lang' attribute.",
@@ -465,10 +626,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr lang="en">
-            </tr>
+            <table lang="en">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->lang(Language::ENGLISH)
                 ->render(),
             "Failed asserting that element renders correctly with 'lang' attribute.",
@@ -479,10 +640,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr itemid="https://example.com/item" itemprop="name" itemref="info" itemscope itemtype="https://schema.org/Thing">
-            </tr>
+            <table itemid="https://example.com/item" itemprop="name" itemref="info" itemscope itemtype="https://schema.org/Thing">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->itemId('https://example.com/item')
                 ->itemProp('name')
                 ->itemRef('info')
@@ -497,10 +658,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr>
-            </tr>
+            <table>
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->addAriaAttribute('label', 'value')
                 ->removeAriaAttribute('label')
                 ->render(),
@@ -512,10 +673,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr>
-            </tr>
+            <table>
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->setAttribute('class', 'value')
                 ->removeAttribute('class')
                 ->render(),
@@ -527,10 +688,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr>
-            </tr>
+            <table>
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->addDataAttribute('value', 'value')
                 ->removeDataAttribute('value')
                 ->render(),
@@ -542,10 +703,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr role="banner">
-            </tr>
+            <table role="banner">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->role('banner')
                 ->render(),
             "Failed asserting that element renders correctly with 'role' attribute.",
@@ -556,10 +717,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr role="banner">
-            </tr>
+            <table role="banner">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->role(Role::BANNER)
                 ->render(),
             "Failed asserting that element renders correctly with 'role' attribute.",
@@ -570,10 +731,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr class="value">
-            </tr>
+            <table class="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->setAttribute('class', 'value')
                 ->render(),
             "Failed asserting that element renders correctly with 'setAttribute()' method.",
@@ -584,10 +745,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr title="value">
-            </tr>
+            <table title="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->setAttribute(GlobalAttribute::TITLE, 'value')
                 ->render(),
             "Failed asserting that element renders correctly with 'setAttribute()' method.",
@@ -598,10 +759,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr spellcheck="true">
-            </tr>
+            <table spellcheck="true">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->spellcheck(true)
                 ->render(),
             "Failed asserting that element renders correctly with 'spellcheck' attribute.",
@@ -612,10 +773,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr style='value'>
-            </tr>
+            <table style='value'>
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->style('value')
                 ->render(),
             "Failed asserting that element renders correctly with 'style' attribute.",
@@ -626,47 +787,76 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr tabindex="3">
-            </tr>
+            <table tabindex="3">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->tabIndex(3)
                 ->render(),
             "Failed asserting that element renders correctly with 'tabindex' attribute.",
         );
     }
 
-    public function testRenderWithTd(): void
+    public function testRenderWithTbody(): void
     {
         self::assertSame(
             <<<HTML
+            <table>
+            <tbody>
             <tr>
             <td>
             value
             </td>
             </tr>
+            </tbody>
+            </table>
             HTML,
-            Tr::tag()
-                ->td(Td::tag()->content('value'))
+            Table::tag()
+                ->tbody(Tbody::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('value'))))
                 ->render(),
-            "Failed asserting that element renders correctly with 'td()' method.",
+            "Failed asserting that element renders correctly with 'tbody()' method.",
         );
     }
 
-    public function testRenderWithTh(): void
+    public function testRenderWithTfoot(): void
     {
         self::assertSame(
             <<<HTML
+            <table>
+            <tfoot>
+            <tr>
+            <td>
+            value
+            </td>
+            </tr>
+            </tfoot>
+            </table>
+            HTML,
+            Table::tag()
+                ->tfoot(Tfoot::tag()->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('value'))))
+                ->render(),
+            "Failed asserting that element renders correctly with 'tfoot()' method.",
+        );
+    }
+
+    public function testRenderWithThead(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <table>
+            <thead>
             <tr>
             <th>
             value
             </th>
             </tr>
+            </thead>
+            </table>
             HTML,
-            Tr::tag()
-                ->th(Th::tag()->content('value'))
+            Table::tag()
+                ->thead(Thead::tag()->tr(Tr::tag()->th(\UIAwesome\Html\Table\Th::tag()->content('value'))))
                 ->render(),
-            "Failed asserting that element renders correctly with 'th()' method.",
+            "Failed asserting that element renders correctly with 'thead()' method.",
         );
     }
 
@@ -674,10 +864,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr class="text-muted">
-            </tr>
+            <table class="text-muted">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->addThemeProvider('muted', DefaultThemeProvider::class)
                 ->render(),
             "Failed asserting that element renders correctly with 'addThemeProvider()' method.",
@@ -688,10 +878,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr title="value">
-            </tr>
+            <table title="value">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->title('value')
                 ->render(),
             "Failed asserting that element renders correctly with 'title' attribute.",
@@ -702,11 +892,30 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr>
-            </tr>
+            <table>
+            </table>
             HTML,
-            (string) Tr::tag(),
+            (string) Table::tag(),
             "Failed asserting that '__toString()' method renders correctly.",
+        );
+    }
+
+    public function testRenderWithTr(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <table>
+            <tr>
+            <td>
+            value
+            </td>
+            </tr>
+            </table>
+            HTML,
+            Table::tag()
+                ->tr(Tr::tag()->td(\UIAwesome\Html\Table\Td::tag()->content('value')))
+                ->render(),
+            "Failed asserting that element renders correctly with 'tr()' method.",
         );
     }
 
@@ -714,10 +923,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr translate="no">
-            </tr>
+            <table translate="no">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->translate(false)
                 ->render(),
             "Failed asserting that element renders correctly with 'translate' attribute.",
@@ -728,10 +937,10 @@ final class TrTest extends TestCase
     {
         self::assertSame(
             <<<HTML
-            <tr translate="no">
-            </tr>
+            <table translate="no">
+            </table>
             HTML,
-            Tr::tag()
+            Table::tag()
                 ->translate(Translate::NO)
                 ->render(),
             "Failed asserting that element renders correctly with 'translate' attribute.",
@@ -741,7 +950,7 @@ final class TrTest extends TestCase
     public function testRenderWithUserOverridesGlobalDefaults(): void
     {
         SimpleFactory::setDefaults(
-            Tr::class,
+            Table::class,
             [
                 'class' => 'from-global',
                 'id' => 'id-global',
@@ -750,81 +959,51 @@ final class TrTest extends TestCase
 
         self::assertSame(
             <<<HTML
-            <tr class="from-global" id="value">
-            </tr>
+            <table class="from-global" id="value">
+            </table>
             HTML,
-            Tr::tag(['id' => 'value'])->render(),
+            Table::tag(['id' => 'value'])->render(),
             'Failed asserting that user-defined attributes override global defaults correctly.',
         );
 
         SimpleFactory::setDefaults(
-            Tr::class,
+            Table::class,
             [],
-        );
-    }
-
-    public function testRenderWithCells(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <tr>
-            <td>
-            Jane
-            </td>
-            <td>
-            30
-            </td>
-            </tr>
-            HTML,
-            Tr::tag()
-                ->cells('Jane', '30')
-                ->render(),
-            "Failed asserting that element renders correctly with 'cells()' method.",
-        );
-    }
-
-    public function testRenderWithHeaderCells(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <tr>
-            <th>
-            Name
-            </th>
-            <th>
-            Age
-            </th>
-            </tr>
-            HTML,
-            Tr::tag()
-                ->headerCells('Name', 'Age')
-                ->render(),
-            "Failed asserting that element renders correctly with 'headerCells()' method.",
         );
     }
 
     public function testReturnNewInstanceWhenSettingAttribute(): void
     {
-        $tr = Tr::tag();
+        $table = Table::tag();
 
         self::assertNotSame(
-            $tr,
-            $tr->cells('value'),
+            $table,
+            $table->caption('value'),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
         self::assertNotSame(
-            $tr,
-            $tr->headerCells('value'),
+            $table,
+            $table->colgroup(Colgroup::tag()),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
         self::assertNotSame(
-            $tr,
-            $tr->td(Td::tag()),
+            $table,
+            $table->thead(Thead::tag()),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
         self::assertNotSame(
-            $tr,
-            $tr->th(Th::tag()),
+            $table,
+            $table->tbody(Tbody::tag()),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $table,
+            $table->tr(Tr::tag()),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $table,
+            $table->tfoot(Tfoot::tag()),
             'Should return a new instance when setting the attribute, ensuring immutability.',
         );
     }
@@ -840,7 +1019,7 @@ final class TrTest extends TestCase
             ),
         );
 
-        Tr::tag()->contentEditable('invalid-value');
+        Table::tag()->contentEditable('invalid-value');
     }
 
     public function testThrowInvalidArgumentExceptionWhenSettingDir(): void
@@ -854,7 +1033,7 @@ final class TrTest extends TestCase
             ),
         );
 
-        Tr::tag()->dir('invalid-value');
+        Table::tag()->dir('invalid-value');
     }
 
     public function testThrowInvalidArgumentExceptionWhenSettingDraggable(): void
@@ -868,7 +1047,7 @@ final class TrTest extends TestCase
             ),
         );
 
-        Tr::tag()->draggable('invalid-value');
+        Table::tag()->draggable('invalid-value');
     }
 
     public function testThrowInvalidArgumentExceptionWhenSettingLang(): void
@@ -882,7 +1061,7 @@ final class TrTest extends TestCase
             ),
         );
 
-        Tr::tag()->lang('invalid-value');
+        Table::tag()->lang('invalid-value');
     }
 
     public function testThrowInvalidArgumentExceptionWhenSettingRole(): void
@@ -896,7 +1075,7 @@ final class TrTest extends TestCase
             ),
         );
 
-        Tr::tag()->role('invalid-value');
+        Table::tag()->role('invalid-value');
     }
 
     public function testThrowInvalidArgumentExceptionWhenSettingTabindex(): void
@@ -910,7 +1089,7 @@ final class TrTest extends TestCase
             ),
         );
 
-        Tr::tag()->tabIndex(-2);
+        Table::tag()->tabIndex(-2);
     }
 
     public function testThrowInvalidArgumentExceptionWhenSettingTranslate(): void
@@ -924,6 +1103,6 @@ final class TrTest extends TestCase
             ),
         );
 
-        Tr::tag()->translate('invalid-value');
+        Table::tag()->translate('invalid-value');
     }
 }

--- a/tests/Table/TbodyTest.php
+++ b/tests/Table/TbodyTest.php
@@ -618,6 +618,28 @@ final class TbodyTest extends TestCase
         );
     }
 
+    public function testRenderWithRowsUsingAssociativeArrays(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tbody>
+            <tr>
+            <td>
+            Jane
+            </td>
+            <td>
+            30
+            </td>
+            </tr>
+            </tbody>
+            HTML,
+            Tbody::tag()
+                ->rows(['name' => 'Jane', 'age' => '30'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'rows()' method using associative arrays.",
+        );
+    }
+
     public function testRenderWithSetAttribute(): void
     {
         self::assertSame(

--- a/tests/Table/TbodyTest.php
+++ b/tests/Table/TbodyTest.php
@@ -566,6 +566,58 @@ final class TbodyTest extends TestCase
         );
     }
 
+    public function testRenderWithRow(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tbody>
+            <tr>
+            <td>
+            Jane
+            </td>
+            <td>
+            30
+            </td>
+            </tr>
+            </tbody>
+            HTML,
+            Tbody::tag()
+                ->row('Jane', '30')
+                ->render(),
+            "Failed asserting that element renders correctly with 'row()' method.",
+        );
+    }
+
+    public function testRenderWithRows(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tbody>
+            <tr>
+            <td>
+            Jane
+            </td>
+            <td>
+            30
+            </td>
+            </tr>
+            <tr>
+            <td>
+            John
+            </td>
+            <td>
+            25
+            </td>
+            </tr>
+            </tbody>
+            HTML,
+            Tbody::tag()
+                ->rows(['Jane', '30'], ['John', '25'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'rows()' method.",
+        );
+    }
+
     public function testRenderWithSetAttribute(): void
     {
         self::assertSame(
@@ -743,58 +795,6 @@ final class TbodyTest extends TestCase
         SimpleFactory::setDefaults(
             Tbody::class,
             [],
-        );
-    }
-
-    public function testRenderWithRow(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <tbody>
-            <tr>
-            <td>
-            Jane
-            </td>
-            <td>
-            30
-            </td>
-            </tr>
-            </tbody>
-            HTML,
-            Tbody::tag()
-                ->row('Jane', '30')
-                ->render(),
-            "Failed asserting that element renders correctly with 'row()' method.",
-        );
-    }
-
-    public function testRenderWithRows(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <tbody>
-            <tr>
-            <td>
-            Jane
-            </td>
-            <td>
-            30
-            </td>
-            </tr>
-            <tr>
-            <td>
-            John
-            </td>
-            <td>
-            25
-            </td>
-            </tr>
-            </tbody>
-            HTML,
-            Tbody::tag()
-                ->rows(['Jane', '30'], ['John', '25'])
-                ->render(),
-            "Failed asserting that element renders correctly with 'rows()' method.",
         );
     }
 

--- a/tests/Table/TbodyTest.php
+++ b/tests/Table/TbodyTest.php
@@ -29,7 +29,7 @@ use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
  * Unit tests for {@see Tbody} rendering and body row composition behavior.
  *
  * Test coverage.
- * - Appends table body rows using `tr()` and renders expected output.
+ * - Appends table body rows using `tr()`, `row()`, and `rows()` and renders expected output.
  * - Applies global and custom attributes, including `aria-*`, `data-*` and enum-backed values.
  * - Ensures attribute accessors return assigned values and fallback defaults.
  * - Renders content, raw HTML, begin/end usage, and string casting with expected encoding behavior.
@@ -746,10 +746,72 @@ final class TbodyTest extends TestCase
         );
     }
 
+    public function testRenderWithRow(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tbody>
+            <tr>
+            <td>
+            Jane
+            </td>
+            <td>
+            30
+            </td>
+            </tr>
+            </tbody>
+            HTML,
+            Tbody::tag()
+                ->row('Jane', '30')
+                ->render(),
+            "Failed asserting that element renders correctly with 'row()' method.",
+        );
+    }
+
+    public function testRenderWithRows(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tbody>
+            <tr>
+            <td>
+            Jane
+            </td>
+            <td>
+            30
+            </td>
+            </tr>
+            <tr>
+            <td>
+            John
+            </td>
+            <td>
+            25
+            </td>
+            </tr>
+            </tbody>
+            HTML,
+            Tbody::tag()
+                ->rows(['Jane', '30'], ['John', '25'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'rows()' method.",
+        );
+    }
+
     public function testReturnNewInstanceWhenSettingAttribute(): void
     {
         $tbody = Tbody::tag();
 
+        self::assertNotSame(
+            $tbody,
+            $tbody->row('value'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $tbody,
+            $tbody->rows(['value']),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
         self::assertNotSame(
             $tbody,
             $tbody->tr(Tr::tag()),

--- a/tests/Table/TfootTest.php
+++ b/tests/Table/TfootTest.php
@@ -618,6 +618,28 @@ final class TfootTest extends TestCase
         );
     }
 
+    public function testRenderWithRowsUsingAssociativeArrays(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tfoot>
+            <tr>
+            <td>
+            Totals
+            </td>
+            <td>
+            100
+            </td>
+            </tr>
+            </tfoot>
+            HTML,
+            Tfoot::tag()
+                ->rows(['label' => 'Totals', 'value' => '100'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'rows()' method using associative arrays.",
+        );
+    }
+
     public function testRenderWithSetAttribute(): void
     {
         self::assertSame(

--- a/tests/Table/TfootTest.php
+++ b/tests/Table/TfootTest.php
@@ -566,6 +566,58 @@ final class TfootTest extends TestCase
         );
     }
 
+    public function testRenderWithRow(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tfoot>
+            <tr>
+            <td>
+            Totals
+            </td>
+            <td>
+            100
+            </td>
+            </tr>
+            </tfoot>
+            HTML,
+            Tfoot::tag()
+                ->row('Totals', '100')
+                ->render(),
+            "Failed asserting that element renders correctly with 'row()' method.",
+        );
+    }
+
+    public function testRenderWithRows(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tfoot>
+            <tr>
+            <td>
+            Subtotal
+            </td>
+            <td>
+            80
+            </td>
+            </tr>
+            <tr>
+            <td>
+            Total
+            </td>
+            <td>
+            100
+            </td>
+            </tr>
+            </tfoot>
+            HTML,
+            Tfoot::tag()
+                ->rows(['Subtotal', '80'], ['Total', '100'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'rows()' method.",
+        );
+    }
+
     public function testRenderWithSetAttribute(): void
     {
         self::assertSame(
@@ -743,58 +795,6 @@ final class TfootTest extends TestCase
         SimpleFactory::setDefaults(
             Tfoot::class,
             [],
-        );
-    }
-
-    public function testRenderWithRow(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <tfoot>
-            <tr>
-            <td>
-            Totals
-            </td>
-            <td>
-            100
-            </td>
-            </tr>
-            </tfoot>
-            HTML,
-            Tfoot::tag()
-                ->row('Totals', '100')
-                ->render(),
-            "Failed asserting that element renders correctly with 'row()' method.",
-        );
-    }
-
-    public function testRenderWithRows(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <tfoot>
-            <tr>
-            <td>
-            Subtotal
-            </td>
-            <td>
-            80
-            </td>
-            </tr>
-            <tr>
-            <td>
-            Total
-            </td>
-            <td>
-            100
-            </td>
-            </tr>
-            </tfoot>
-            HTML,
-            Tfoot::tag()
-                ->rows(['Subtotal', '80'], ['Total', '100'])
-                ->render(),
-            "Failed asserting that element renders correctly with 'rows()' method.",
         );
     }
 

--- a/tests/Table/TfootTest.php
+++ b/tests/Table/TfootTest.php
@@ -29,7 +29,7 @@ use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
  * Unit tests for {@see Tfoot} rendering and footer row composition behavior.
  *
  * Test coverage.
- * - Appends table footer rows using `tr()` and renders expected output.
+ * - Appends table footer rows using `tr()`, `row()`, and `rows()` and renders expected output.
  * - Applies global and custom attributes, including `aria-*`, `data-*` and enum-backed values.
  * - Ensures attribute accessors return assigned values and fallback defaults.
  * - Renders content, raw HTML, begin/end usage, and string casting with expected encoding behavior.
@@ -746,10 +746,72 @@ final class TfootTest extends TestCase
         );
     }
 
+    public function testRenderWithRow(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tfoot>
+            <tr>
+            <td>
+            Totals
+            </td>
+            <td>
+            100
+            </td>
+            </tr>
+            </tfoot>
+            HTML,
+            Tfoot::tag()
+                ->row('Totals', '100')
+                ->render(),
+            "Failed asserting that element renders correctly with 'row()' method.",
+        );
+    }
+
+    public function testRenderWithRows(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tfoot>
+            <tr>
+            <td>
+            Subtotal
+            </td>
+            <td>
+            80
+            </td>
+            </tr>
+            <tr>
+            <td>
+            Total
+            </td>
+            <td>
+            100
+            </td>
+            </tr>
+            </tfoot>
+            HTML,
+            Tfoot::tag()
+                ->rows(['Subtotal', '80'], ['Total', '100'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'rows()' method.",
+        );
+    }
+
     public function testReturnNewInstanceWhenSettingAttribute(): void
     {
         $tfoot = Tfoot::tag();
 
+        self::assertNotSame(
+            $tfoot,
+            $tfoot->row('value'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $tfoot,
+            $tfoot->rows(['value']),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
         self::assertNotSame(
             $tfoot,
             $tfoot->tr(Tr::tag()),

--- a/tests/Table/TheadTest.php
+++ b/tests/Table/TheadTest.php
@@ -29,7 +29,7 @@ use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
  * Unit tests for {@see Thead} rendering and header row composition behavior.
  *
  * Test coverage.
- * - Appends table header rows using `tr()` and renders expected output.
+ * - Appends table header rows using `tr()`, `row()`, and `rows()` and renders expected output.
  * - Applies global and custom attributes, including `aria-*`, `data-*` and enum-backed values.
  * - Ensures attribute accessors return assigned values and fallback defaults.
  * - Renders content, raw HTML, begin/end usage, and string casting with expected encoding behavior.
@@ -748,10 +748,72 @@ final class TheadTest extends TestCase
         );
     }
 
+    public function testRenderWithRow(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <thead>
+            <tr>
+            <th>
+            Name
+            </th>
+            <th>
+            Age
+            </th>
+            </tr>
+            </thead>
+            HTML,
+            Thead::tag()
+                ->row('Name', 'Age')
+                ->render(),
+            "Failed asserting that element renders correctly with 'row()' method.",
+        );
+    }
+
+    public function testRenderWithRows(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <thead>
+            <tr>
+            <th>
+            Name
+            </th>
+            <th>
+            Age
+            </th>
+            </tr>
+            <tr>
+            <th>
+            ID
+            </th>
+            <th>
+            Email
+            </th>
+            </tr>
+            </thead>
+            HTML,
+            Thead::tag()
+                ->rows(['Name', 'Age'], ['ID', 'Email'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'rows()' method.",
+        );
+    }
+
     public function testReturnNewInstanceWhenSettingAttribute(): void
     {
         $thead = Thead::tag();
 
+        self::assertNotSame(
+            $thead,
+            $thead->row('value'),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $thead,
+            $thead->rows(['value']),
+            'Should return a new instance when setting the attribute, ensuring immutability.',
+        );
         self::assertNotSame(
             $thead,
             $thead->tr(Tr::tag()),

--- a/tests/Table/TheadTest.php
+++ b/tests/Table/TheadTest.php
@@ -566,6 +566,58 @@ final class TheadTest extends TestCase
         );
     }
 
+    public function testRenderWithRow(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <thead>
+            <tr>
+            <th>
+            Name
+            </th>
+            <th>
+            Age
+            </th>
+            </tr>
+            </thead>
+            HTML,
+            Thead::tag()
+                ->row('Name', 'Age')
+                ->render(),
+            "Failed asserting that element renders correctly with 'row()' method.",
+        );
+    }
+
+    public function testRenderWithRows(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <thead>
+            <tr>
+            <th>
+            Name
+            </th>
+            <th>
+            Age
+            </th>
+            </tr>
+            <tr>
+            <th>
+            ID
+            </th>
+            <th>
+            Email
+            </th>
+            </tr>
+            </thead>
+            HTML,
+            Thead::tag()
+                ->rows(['Name', 'Age'], ['ID', 'Email'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'rows()' method.",
+        );
+    }
+
     public function testRenderWithSetAttribute(): void
     {
         self::assertSame(
@@ -745,58 +797,6 @@ final class TheadTest extends TestCase
         SimpleFactory::setDefaults(
             Thead::class,
             [],
-        );
-    }
-
-    public function testRenderWithRow(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <thead>
-            <tr>
-            <th>
-            Name
-            </th>
-            <th>
-            Age
-            </th>
-            </tr>
-            </thead>
-            HTML,
-            Thead::tag()
-                ->row('Name', 'Age')
-                ->render(),
-            "Failed asserting that element renders correctly with 'row()' method.",
-        );
-    }
-
-    public function testRenderWithRows(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <thead>
-            <tr>
-            <th>
-            Name
-            </th>
-            <th>
-            Age
-            </th>
-            </tr>
-            <tr>
-            <th>
-            ID
-            </th>
-            <th>
-            Email
-            </th>
-            </tr>
-            </thead>
-            HTML,
-            Thead::tag()
-                ->rows(['Name', 'Age'], ['ID', 'Email'])
-                ->render(),
-            "Failed asserting that element renders correctly with 'rows()' method.",
         );
     }
 

--- a/tests/Table/TheadTest.php
+++ b/tests/Table/TheadTest.php
@@ -618,6 +618,28 @@ final class TheadTest extends TestCase
         );
     }
 
+    public function testRenderWithRowsUsingAssociativeArrays(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <thead>
+            <tr>
+            <th>
+            Name
+            </th>
+            <th>
+            Age
+            </th>
+            </tr>
+            </thead>
+            HTML,
+            Thead::tag()
+                ->rows(['col1' => 'Name', 'col2' => 'Age'])
+                ->render(),
+            "Failed asserting that element renders correctly with 'rows()' method using associative arrays.",
+        );
+    }
+
     public function testRenderWithSetAttribute(): void
     {
         self::assertSame(

--- a/tests/Table/TrTest.php
+++ b/tests/Table/TrTest.php
@@ -238,6 +238,30 @@ final class TrTest extends TestCase
         );
     }
 
+    public function testRenderWithCellsUsingStringable(): void
+    {
+        $name = new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'Jane';
+            }
+        };
+
+        self::assertSame(
+            <<<HTML
+            <tr>
+            <td>
+            Jane
+            </td>
+            </tr>
+            HTML,
+            Tr::tag()
+                ->cells($name)
+                ->render(),
+            "Failed asserting that element renders correctly with 'cells()' method using Stringable.",
+        );
+    }
+
     public function testRenderWithClass(): void
     {
         self::assertSame(
@@ -456,6 +480,30 @@ final class TrTest extends TestCase
                 ->headerCells('Name', 'Age')
                 ->render(),
             "Failed asserting that element renders correctly with 'headerCells()' method.",
+        );
+    }
+
+    public function testRenderWithHeaderCellsUsingStringable(): void
+    {
+        $header = new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'Name';
+            }
+        };
+
+        self::assertSame(
+            <<<HTML
+            <tr>
+            <th>
+            Name
+            </th>
+            </tr>
+            HTML,
+            Tr::tag()
+                ->headerCells($header)
+                ->render(),
+            "Failed asserting that element renders correctly with 'headerCells()' method using Stringable.",
         );
     }
 

--- a/tests/Table/TrTest.php
+++ b/tests/Table/TrTest.php
@@ -218,6 +218,26 @@ final class TrTest extends TestCase
         );
     }
 
+    public function testRenderWithCells(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tr>
+            <td>
+            Jane
+            </td>
+            <td>
+            30
+            </td>
+            </tr>
+            HTML,
+            Tr::tag()
+                ->cells('Jane', '30')
+                ->render(),
+            "Failed asserting that element renders correctly with 'cells()' method.",
+        );
+    }
+
     public function testRenderWithClass(): void
     {
         self::assertSame(
@@ -416,6 +436,26 @@ final class TrTest extends TestCase
         SimpleFactory::setDefaults(
             Tr::class,
             [],
+        );
+    }
+
+    public function testRenderWithHeaderCells(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <tr>
+            <th>
+            Name
+            </th>
+            <th>
+            Age
+            </th>
+            </tr>
+            HTML,
+            Tr::tag()
+                ->headerCells('Name', 'Age')
+                ->render(),
+            "Failed asserting that element renders correctly with 'headerCells()' method.",
         );
     }
 
@@ -760,46 +800,6 @@ final class TrTest extends TestCase
         SimpleFactory::setDefaults(
             Tr::class,
             [],
-        );
-    }
-
-    public function testRenderWithCells(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <tr>
-            <td>
-            Jane
-            </td>
-            <td>
-            30
-            </td>
-            </tr>
-            HTML,
-            Tr::tag()
-                ->cells('Jane', '30')
-                ->render(),
-            "Failed asserting that element renders correctly with 'cells()' method.",
-        );
-    }
-
-    public function testRenderWithHeaderCells(): void
-    {
-        self::assertSame(
-            <<<HTML
-            <tr>
-            <th>
-            Name
-            </th>
-            <th>
-            Age
-            </th>
-            </tr>
-            HTML,
-            Tr::tag()
-                ->headerCells('Name', 'Age')
-                ->render(),
-            "Failed asserting that element renders correctly with 'headerCells()' method.",
         );
     }
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
