### PR TITLE
feat(form)!: add typed `ChoiceItem`, `CheckboxList`, and `RadioList` controls, add `Select::value()`, and make `Select::options()` take `Option`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.5.0 Under development
 
 - feat!: require `ui-awesome/html-core 0.7` and remove support for global `SimpleFactory` defaults and make `Select` and `TextArea` implement `FormControlInterface`.
+- feat(form)!: add typed `ChoiceItem`, `CheckboxList`, and `RadioList` controls, add `Select::value()`, and make `Select::options()` take `Option`.
 
 ## 0.4.3 July 21, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat!: require `ui-awesome/html-core 0.7` and remove support for global `SimpleFactory` defaults and make `Select` and `TextArea` implement `FormControlInterface`.
 - feat(form)!: add typed `ChoiceItem`, `CheckboxList`, and `RadioList` controls, add `Select::value()`, and make `Select::options()` take `Option`.
+- fix(form)!: match a checkbox or radio without a `value` attribute against `on`, the value browsers submit for it.
 
 ## 0.4.3 July 21, 2026
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,35 @@ $metadata = Dl::tag()
 $html = $features->render() . PHP_EOL . $steps->render() . PHP_EOL . $metadata->render();
 ```
 
+#### Typed form choices
+
+Build selects and choice lists from typed objects. Selection state stays on the composite control while each option
+keeps its own submitted value.
+
+```php
+use UIAwesome\Html\Form\{CheckboxList, ChoiceItem, Option, Select};
+
+$pet = Select::tag()
+    ->name('pet')
+    ->options(
+        Option::tag()->value('dog')->content('Dog'),
+        Option::tag()->value('cat')->content('Cat'),
+    )
+    ->value('cat');
+
+$channels = CheckboxList::tag()
+    ->id('channels')
+    ->name('channels')
+    ->items(
+        ChoiceItem::tag()->value('email')->label('Email'),
+        ChoiceItem::tag()->value('sms')->label('SMS'),
+    )
+    ->checked(['email']);
+
+// Render both controls
+$html = $pet->render() . PHP_EOL . $channels->render();
+```
+
 ## Documentation
 
 For detailed testing and quality workflows.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 ### Installation
 
 ```bash
-composer require ui-awesome/html:^0.4
+composer require ui-awesome/html:^0.5
 ```
 
 ### Quick start

--- a/src/Form/AbstractChoiceList.php
+++ b/src/Form/AbstractChoiceList.php
@@ -195,6 +195,11 @@ abstract class AbstractChoiceList extends BaseBlock implements FormControlInterf
      * $list->uncheckedValue(null);
      * ```
      *
+     * The hidden input always carries the plain list name, never the `name[]` form used by {@see CheckboxList} items,
+     * so that a checked item overwrites the fallback under PHP's query-string parsing: `name=0&name[]=1` yields
+     * `['1']`, while `name[]=0&name[]=1` would keep the fallback as `['0', '1']`. Consumers that do not apply that
+     * bracket normalization, such as the `FormData` API, receive `name` and `name[]` as separate keys.
+     *
      * @param bool|float|int|string|Stringable|UnitEnum|null $value Fallback value, or `null` to omit the hidden input.
      *
      * @return static New instance with the updated unchecked value.

--- a/src/Form/AbstractChoiceList.php
+++ b/src/Form/AbstractChoiceList.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form;
+
+use Override;
+use Stringable;
+use UIAwesome\Html\Attribute\HasName;
+use UIAwesome\Html\Contracts\Form\FormControlInterface;
+use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Core\Html;
+use UIAwesome\Html\Interop\Block;
+use UnitEnum;
+
+use function array_values;
+use function implode;
+use function is_string;
+
+/**
+ * Provides shared immutable rendering behavior for checkbox and radio lists.
+ *
+ * Renders every {@see ChoiceItem} as an atomic input paired with a `<label>`, wrapped in a container element that
+ * carries the list attributes. Selection is configured on the list through {@see checked()}, never on the items.
+ *
+ * {@see CheckboxList} for the checkbox implementation.
+ * {@see RadioList} for the radio implementation.
+ */
+abstract class AbstractChoiceList extends BaseBlock implements FormControlInterface
+{
+    use HasName;
+
+    /**
+     * Values determining which items are checked.
+     *
+     * @var array<mixed>|bool|float|int|string|Stringable|UnitEnum|null
+     */
+    private array|bool|float|int|string|Stringable|UnitEnum|null $checked = null;
+    /**
+     * Whether every item input and its text are enclosed by the item label.
+     */
+    private bool $enclosedByLabel = false;
+    /**
+     * @var mixed[] Attributes applied to every item input.
+     */
+    private array $itemAttributes = [];
+    /**
+     * @var list<ChoiceItem> Items rendered by the list.
+     */
+    private array $items = [];
+    /**
+     * Value submitted when no list item is selected.
+     */
+    private bool|float|int|string|Stringable|UnitEnum|null $uncheckedValue = null;
+
+    /**
+     * Creates the atomic input used for each item.
+     *
+     * @return InputCheckbox|InputRadio Input element instance rendered for every item.
+     */
+    abstract protected function createInput(): InputCheckbox|InputRadio;
+
+    /**
+     * Returns whether item names use array notation.
+     *
+     * @return bool `true` when every item input is named `name[]`, `false` when items share the plain list name.
+     */
+    abstract protected function usesArrayName(): bool;
+
+    /**
+     * Sets the values determining which items are checked.
+     *
+     * Usage example:
+     * ```php
+     * $list->checked('email');
+     * $list->checked(['email', 'sms']);
+     * $list->checked(null);
+     * ```
+     *
+     * @param array<mixed>|bool|float|int|string|Stringable|UnitEnum|null $value Checked values.
+     *
+     * - `array`: Every item whose value is in the array is checked.
+     * - `false`: No item is checked.
+     * - `true`: Every item is checked.
+     * - `float|int|string|Stringable|UnitEnum`: The item whose value matches is checked.
+     * - `null`: No item is checked.
+     *
+     * @return static New instance with the updated checked values.
+     */
+    public function checked(array|bool|float|int|string|Stringable|UnitEnum|null $value): static
+    {
+        $new = clone $this;
+        $new->checked = $value;
+
+        return $new;
+    }
+
+    /**
+     * Configures whether every item input and its text are enclosed by the item label.
+     *
+     * Usage example:
+     * ```php
+     * $list->enclosedByLabel();
+     * $list->enclosedByLabel(false);
+     * ```
+     *
+     * @param bool $value Enclosure state. Use `true` to wrap the input inside its `<label>`, `false` to render the
+     * input and the label as siblings.
+     *
+     * @return static New instance with the updated label enclosure state.
+     */
+    public function enclosedByLabel(bool $value = true): static
+    {
+        $new = clone $this;
+        $new->enclosedByLabel = $value;
+
+        return $new;
+    }
+
+    /**
+     * Identifies this control as a list so field wrappers render a group label instead of a `for` label.
+     *
+     * Usage example:
+     * ```php
+     * if ($list->isList()) {
+     *     // Render a group label instead of a label bound to a single control.
+     * }
+     * ```
+     *
+     * @return true Always `true`.
+     */
+    public function isList(): true
+    {
+        return true;
+    }
+
+    /**
+     * Sets attributes applied to every item input.
+     *
+     * Merges with the attributes already configured, so consecutive calls accumulate.
+     *
+     * Usage example:
+     * ```php
+     * $list->itemAttributes(['class' => 'choice']);
+     * $list->itemAttributes(['data-state' => 'ready']);
+     * ```
+     *
+     * @param mixed[] $values Input attributes indexed by attribute name.
+     *
+     * @return static New instance with the updated item attributes.
+     */
+    public function itemAttributes(array $values): static
+    {
+        $new = clone $this;
+        $new->itemAttributes = [...$new->itemAttributes, ...$values];
+
+        return $new;
+    }
+
+    /**
+     * Replaces the items rendered by the list.
+     *
+     * Usage example:
+     * ```php
+     * $list->items(
+     *     \UIAwesome\Html\Form\ChoiceItem::tag()->value('email')->label('Email'),
+     *     \UIAwesome\Html\Form\ChoiceItem::tag()->value('sms')->label('SMS'),
+     * );
+     * ```
+     *
+     * @param ChoiceItem ...$items Item instances rendered in order.
+     *
+     * @return static New instance with the replacement items.
+     */
+    public function items(ChoiceItem ...$items): static
+    {
+        $new = clone $this;
+        $new->items = array_values($items);
+
+        return $new;
+    }
+
+    /**
+     * Sets the value submitted when no list item is selected.
+     *
+     * Renders a hidden input carrying the list name before the items, and is skipped when the list has no name.
+     *
+     * Usage example:
+     * ```php
+     * $list->uncheckedValue('0');
+     * $list->uncheckedValue(null);
+     * ```
+     *
+     * @param bool|float|int|string|Stringable|UnitEnum|null $value Fallback value, or `null` to omit the hidden input.
+     *
+     * @return static New instance with the updated unchecked value.
+     */
+    public function uncheckedValue(bool|float|int|string|Stringable|UnitEnum|null $value): static
+    {
+        $new = clone $this;
+        $new->uncheckedValue = $value;
+
+        return $new;
+    }
+
+    /**
+     * Returns the tag enumeration for the list container.
+     *
+     * @return Block Tag enumeration instance for `<div>`.
+     */
+    protected function getTag(): Block
+    {
+        return Block::DIV;
+    }
+
+    /**
+     * Renders the list container with its content, the unchecked input, and every item.
+     *
+     * The `name` attribute is transferred to the item inputs instead of being serialized on the container.
+     *
+     * @return string Rendered HTML for the choice list.
+     */
+    #[Override]
+    protected function run(): string
+    {
+        if ($this->isBeginExecuted()) {
+            return parent::run();
+        }
+
+        $containerAttributes = $this->getAttributes();
+
+        $id = $containerAttributes['id'] ?? null;
+        $name = $containerAttributes['name'] ?? null;
+
+        unset($containerAttributes['name']);
+
+        $id = is_string($id) ? $id : null;
+        $name = is_string($name) ? $name : null;
+        $inputName = $name !== null && $this->usesArrayName() ? "{$name}[]" : $name;
+
+        $content = [];
+
+        if ($this->uncheckedValue !== null && $name !== null) {
+            $content[] = InputHidden::tag()
+                ->name($name)
+                ->value($this->uncheckedValue)
+                ->render();
+        }
+
+        foreach ($this->items as $index => $item) {
+            $content[] = $item->render(
+                $this->createInput(),
+                $this->itemAttributes,
+                $id === null ? null : "{$id}-{$index}",
+                $inputName,
+                $this->checked,
+                $this->enclosedByLabel,
+            );
+        }
+
+        return Html::element(
+            $this->getTag(),
+            $this->getContent() . implode("\n", $content),
+            $containerAttributes,
+        );
+    }
+}

--- a/src/Form/AbstractChoiceList.php
+++ b/src/Form/AbstractChoiceList.php
@@ -7,6 +7,7 @@ namespace UIAwesome\Html\Form;
 use Override;
 use Stringable;
 use UIAwesome\Html\Attribute\HasName;
+use UIAwesome\Html\Attribute\Values\{ElementAttribute, GlobalAttribute};
 use UIAwesome\Html\Contracts\Form\FormControlInterface;
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Core\Html;
@@ -230,13 +231,8 @@ abstract class AbstractChoiceList extends BaseBlock implements FormControlInterf
             return parent::run();
         }
 
-        $containerAttributes = $this->getAttributes();
-
-        $id = $this->normalizeIdentifier($containerAttributes['id'] ?? null);
-        $name = $this->normalizeIdentifier($containerAttributes['name'] ?? null);
-
-        unset($containerAttributes['name']);
-
+        $id = $this->normalizeIdentifier($this->getAttribute(GlobalAttribute::ID));
+        $name = $this->normalizeIdentifier($this->getAttribute(ElementAttribute::NAME));
         $inputName = $name !== null && $this->usesArrayName() ? "{$name}[]" : $name;
 
         $content = [];
@@ -262,8 +258,36 @@ abstract class AbstractChoiceList extends BaseBlock implements FormControlInterf
         return Html::element(
             $this->getTag(),
             $this->getContent() . implode("\n", $content),
-            $containerAttributes,
+            $this->containerAttributes(),
         );
+    }
+
+    /**
+     * Returns the opening tag for begin/end rendering.
+     *
+     * @return string Opening HTML tag for the list container.
+     */
+    #[Override]
+    protected function runBegin(): string
+    {
+        return Html::begin($this->getTag(), $this->containerAttributes());
+    }
+
+    /**
+     * Returns the attributes serialized on the list container.
+     *
+     * The `name` attribute is transferred to the item inputs, so it is never serialized on the container, which is
+     * not a submitting element.
+     *
+     * @return mixed[] Attributes serialized on the container.
+     */
+    private function containerAttributes(): array
+    {
+        $attributes = $this->getAttributes();
+
+        unset($attributes[ElementAttribute::NAME->value]);
+
+        return $attributes;
     }
 
     /**

--- a/src/Form/AbstractChoiceList.php
+++ b/src/Form/AbstractChoiceList.php
@@ -10,6 +10,7 @@ use UIAwesome\Html\Attribute\HasName;
 use UIAwesome\Html\Contracts\Form\FormControlInterface;
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Core\Html;
+use UIAwesome\Html\Helper\Enum;
 use UIAwesome\Html\Interop\Block;
 use UnitEnum;
 
@@ -231,13 +232,11 @@ abstract class AbstractChoiceList extends BaseBlock implements FormControlInterf
 
         $containerAttributes = $this->getAttributes();
 
-        $id = $containerAttributes['id'] ?? null;
-        $name = $containerAttributes['name'] ?? null;
+        $id = $this->normalizeIdentifier($containerAttributes['id'] ?? null);
+        $name = $this->normalizeIdentifier($containerAttributes['name'] ?? null);
 
         unset($containerAttributes['name']);
 
-        $id = is_string($id) ? $id : null;
-        $name = is_string($name) ? $name : null;
         $inputName = $name !== null && $this->usesArrayName() ? "{$name}[]" : $name;
 
         $content = [];
@@ -265,5 +264,24 @@ abstract class AbstractChoiceList extends BaseBlock implements FormControlInterf
             $this->getContent() . implode("\n", $content),
             $containerAttributes,
         );
+    }
+
+    /**
+     * Normalizes a container identifier to the string transferred to the item inputs.
+     *
+     * Accepts the types allowed by {@see HasId::id()} and {@see HasName::name()}; any other value assigned through
+     * {@see addAttribute()} is not a supported identifier and yields `null`.
+     *
+     * @param mixed $value Identifier assigned to the container.
+     *
+     * @return string|null Normalized identifier, or `null` when the value is not a supported identifier type.
+     */
+    private function normalizeIdentifier(mixed $value): string|null
+    {
+        return match (true) {
+            is_string($value) => $value,
+            $value instanceof Stringable, $value instanceof UnitEnum => Enum::normalizeStringValue($value),
+            default => null,
+        };
     }
 }

--- a/src/Form/AbstractChoiceList.php
+++ b/src/Form/AbstractChoiceList.php
@@ -128,6 +128,8 @@ abstract class AbstractChoiceList extends BaseBlock implements FormControlInterf
      * ```
      *
      * @return true Always `true`.
+     *
+     * @codeCoverageIgnore
      */
     public function isList(): true
     {

--- a/src/Form/CheckboxList.php
+++ b/src/Form/CheckboxList.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form;
+
+/**
+ * Renders a list of `<input type="checkbox">` controls sharing one name.
+ *
+ * Every item input is named `name[]` so the browser submits the checked values as an array.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Form\CheckboxList::tag()
+ *     ->checked(['email'])
+ *     ->id('channels')
+ *     ->items(
+ *         \UIAwesome\Html\Form\ChoiceItem::tag()->value('email')->label('Email'),
+ *         \UIAwesome\Html\Form\ChoiceItem::tag()->value('sms')->label('SMS'),
+ *     )
+ *     ->name('channels')
+ *     ->render();
+ * ```
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/checkbox
+ * {@see AbstractChoiceList} for the base implementation.
+ */
+final class CheckboxList extends AbstractChoiceList
+{
+    /**
+     * Creates the atomic input used for each item.
+     *
+     * @return InputCheckbox Checkbox input element instance.
+     */
+    protected function createInput(): InputCheckbox
+    {
+        return InputCheckbox::tag();
+    }
+
+    /**
+     * Returns whether item names use array notation.
+     *
+     * @return true Always `true`, so every item input is named `name[]`.
+     */
+    protected function usesArrayName(): true
+    {
+        return true;
+    }
+}

--- a/src/Form/ChoiceItem.php
+++ b/src/Form/ChoiceItem.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form;
+
+use Stringable;
+use UIAwesome\Html\Helper\CSSClass;
+use UIAwesome\Html\Phrasing\Label;
+use UnitEnum;
+
+/**
+ * Defines one value and label rendered by a checkbox or radio list.
+ *
+ * The item carries no name, id, or checked state: {@see AbstractChoiceList} derives them from the list and passes them
+ * in on render.
+ *
+ * Usage example:
+ * ```php
+ * $item = \UIAwesome\Html\Form\ChoiceItem::tag()
+ *     ->label('Email')
+ *     ->labelClass('choice-label')
+ *     ->value('email');
+ * ```
+ *
+ * {@see CheckboxList} and {@see RadioList} for the lists rendering the items.
+ */
+final class ChoiceItem
+{
+    /**
+     * Label text, encoded on render.
+     */
+    private string|Stringable $label = '';
+    /**
+     * @var mixed[] Attributes applied to the item label.
+     */
+    private array $labelAttributes = [];
+    /**
+     * Submitted value, or `null` to remove the attribute.
+     */
+    private bool|float|int|string|Stringable|UnitEnum|null $value = null;
+
+    /**
+     * Sets the item label.
+     *
+     * Usage example:
+     * ```php
+     * $item->label('Email');
+     * ```
+     *
+     * @param string|Stringable $value Label text, encoded on render.
+     *
+     * @return self New instance with the updated label.
+     */
+    public function label(string|Stringable $value): self
+    {
+        $new = clone $this;
+        $new->label = $value;
+
+        return $new;
+    }
+
+    /**
+     * Sets attributes applied to the item label.
+     *
+     * Merges with the attributes already configured, so consecutive calls accumulate.
+     *
+     * Usage example:
+     * ```php
+     * $item->labelAttributes(['class' => 'choice-label']);
+     * $item->labelAttributes(['data-item' => 'email']);
+     * ```
+     *
+     * @param mixed[] $values Label attributes indexed by attribute name.
+     *
+     * @return self New instance with the updated label attributes.
+     */
+    public function labelAttributes(array $values): self
+    {
+        $new = clone $this;
+        $new->labelAttributes = [...$new->labelAttributes, ...$values];
+
+        return $new;
+    }
+
+    /**
+     * Adds a CSS class to the item label.
+     *
+     * Usage example:
+     * ```php
+     * $item->labelClass('choice-label');
+     * $item->labelClass('replacement', true);
+     * ```
+     *
+     * @param string|Stringable|UnitEnum|null $value Class name, or `null` to remove the attribute.
+     * @param bool $override Whether to replace the existing classes instead of merging them.
+     *
+     * @return self New instance with the updated label class.
+     */
+    public function labelClass(string|Stringable|UnitEnum|null $value, bool $override = false): self
+    {
+        $new = clone $this;
+        CSSClass::add($new->labelAttributes, $value, $override);
+
+        return $new;
+    }
+
+    /**
+     * Renders the item using an atomic HTML checkbox or radio control.
+     *
+     * @param InputCheckbox|InputRadio $input Input element instance created by the list.
+     * @param mixed[] $attributes Attributes applied to the item input.
+     * @param string|null $id Item identifier shared by the input and its label, or `null` to omit both.
+     * @param string|null $name Name applied to the item input, or `null` to omit the attribute.
+     * @param array<mixed>|bool|float|int|string|Stringable|UnitEnum|null $checked Values determining the checked state.
+     * @param bool $enclosedByLabel Whether the input is wrapped inside its `<label>`.
+     *
+     * @return string Rendered HTML for the item input and its label.
+     *
+     * @internal
+     */
+    public function render(
+        InputCheckbox|InputRadio $input,
+        array $attributes,
+        string|null $id,
+        string|null $name,
+        array|bool|float|int|string|Stringable|UnitEnum|null $checked,
+        bool $enclosedByLabel,
+    ): string {
+        $input = $input
+            ->attributes($attributes)
+            ->checked($checked)
+            ->id($id)
+            ->name($name)
+            ->value($this->value);
+
+        $label = Label::tag()
+            ->attributes($this->labelAttributes)
+            ->for($id);
+
+        return $enclosedByLabel
+            ? $label->html($input->render())->content($this->label)->render()
+            : $input->render() . "\n" . $label->content($this->label)->render();
+    }
+
+    /**
+     * Creates a choice item.
+     *
+     * Usage example:
+     * ```php
+     * $item = \UIAwesome\Html\Form\ChoiceItem::tag();
+     * ```
+     *
+     * @return self New item instance.
+     */
+    public static function tag(): self
+    {
+        return new self();
+    }
+
+    /**
+     * Sets the submitted item value.
+     *
+     * Usage example:
+     * ```php
+     * $item->value('email');
+     * $item->value(null);
+     * ```
+     *
+     * @param bool|float|int|string|Stringable|UnitEnum|null $value Submitted value, or `null` to remove the attribute.
+     *
+     * @return self New instance with the updated value.
+     */
+    public function value(bool|float|int|string|Stringable|UnitEnum|null $value): self
+    {
+        $new = clone $this;
+        $new->value = $value;
+
+        return $new;
+    }
+}

--- a/src/Form/Mixin/HasCheckedState.php
+++ b/src/Form/Mixin/HasCheckedState.php
@@ -18,6 +18,12 @@ use function is_scalar;
 trait HasCheckedState
 {
     /**
+     * Value browsers submit for a checkbox or radio rendered without a `value` attribute.
+     *
+     * @see https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on
+     */
+    private const string DEFAULT_SUBMITTED_VALUE = 'on';
+    /**
      * Determines the checked state of the element.
      *
      * @phpstan-var mixed[]|bool|float|int|string|Stringable|UnitEnum|null
@@ -40,7 +46,8 @@ trait HasCheckedState
      * - `array`: Element is checked if the value is in the array.
      * - `false`: Element is unchecked.
      * - `true`: Element is checked.
-     * - `float|int|string|Stringable|UnitEnum`: Element is checked if the value matches the `value` attribute.
+     * - `float|int|string|Stringable|UnitEnum`: Element is checked if the value matches the `value` attribute, or
+     *   `on` when the element has no `value` attribute.
      * - `null`: Attribute is removed.
      *
      * @return static New instance with the updated `checked` attribute.
@@ -59,7 +66,8 @@ trait HasCheckedState
      * Builds the attributes for the `<input>` element.
      *
      * This method normalizes the `value` attribute and determines the `checked` state based on the current value and
-     * the configured checked options.
+     * the configured checked options. An element without a `value` attribute is matched against `on`, the value
+     * browsers submit for it, while the attribute itself stays omitted.
      *
      * @param array $attributes Initial attributes array.
      *
@@ -84,7 +92,7 @@ trait HasCheckedState
             return $attributes;
         }
 
-        $value = $attributes['value'] ?? null;
+        $value = $attributes['value'] ?? self::DEFAULT_SUBMITTED_VALUE;
 
         if ($normalizedChecked === true) {
             $attributes['checked'] = true;

--- a/src/Form/Mixin/HasSelectableChildren.php
+++ b/src/Form/Mixin/HasSelectableChildren.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form\Mixin;
+
+use UIAwesome\Html\Form\{Optgroup, Option};
+use UIAwesome\Html\Mixin\HasContent;
+
+use function count;
+use function sprintf;
+use function strtr;
+
+/**
+ * Provides deferred child rendering so the parent selection state applies at render time.
+ *
+ * Appending a child writes a placeholder into the content instead of its markup, which keeps the child mutable until
+ * the element renders and preserves its position relative to content added through {@see HasContent::content()} and
+ * {@see HasContent::html()}.
+ *
+ * @mixin HasContent
+ */
+trait HasSelectableChildren
+{
+    /**
+     * Placeholder template written into the content for every appended child.
+     */
+    private const string CHILD_TOKEN = "\x1Aui-awesome-child-%d\x1A";
+    /**
+     * @var list<Optgroup|Option> Children appended to the element.
+     */
+    private array $children = [];
+
+    /**
+     * Appends children while preserving their position in the content.
+     *
+     * @param Optgroup|Option ...$children Child element instances.
+     *
+     * @return static New instance with the appended children.
+     */
+    private function appendChildren(Optgroup|Option ...$children): static
+    {
+        $new = clone $this;
+
+        foreach ($children as $child) {
+            $new->content .= $new->childToken(count($new->children)) . "\n";
+            $new->children[] = $child;
+        }
+
+        return $new;
+    }
+
+    /**
+     * Builds the placeholder for an appended child.
+     *
+     * @param int $index Position of the child in the appended list.
+     *
+     * @return string Placeholder written into the content.
+     */
+    private function childToken(int $index): string
+    {
+        return sprintf(self::CHILD_TOKEN, $index);
+    }
+
+    /**
+     * Replaces every child placeholder with the rendered child.
+     *
+     * @param string[]|null $selectedValues Normalized selected values, or `null` to keep the child selection as
+     * configured.
+     *
+     * @return string Content with the appended children rendered in place.
+     */
+    private function renderChildren(array|null $selectedValues): string
+    {
+        $replacements = [];
+
+        foreach ($this->children as $index => $child) {
+            $replacements[$this->childToken($index)] = $selectedValues === null
+                ? $child->render()
+                : $child->selectedValues($selectedValues)->render();
+        }
+
+        return strtr($this->content, $replacements);
+    }
+}

--- a/src/Form/Optgroup.php
+++ b/src/Form/Optgroup.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Form;
 
+use Override;
 use UIAwesome\Html\Attribute\{CanBeDisabled, HasLabel};
 use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Form\Mixin\HasSelectableChildren;
 use UIAwesome\Html\Form\Values\SelectTag;
 
 /**
@@ -26,9 +28,42 @@ final class Optgroup extends BaseBlock
 {
     use CanBeDisabled;
     use HasLabel;
+    use HasSelectableChildren;
+
+    /**
+     * @var string[]|null Normalized values selected by the parent select.
+     */
+    private array|null $selectedValues = null;
+
+    /**
+     * Returns the content with every appended option rendered in place.
+     *
+     * Options are rendered on access, so the selection received from the parent select is applied to the current option
+     * instances.
+     *
+     * Usage example:
+     * ```php
+     * $html = \UIAwesome\Html\Form\Optgroup::tag()
+     *     ->option(\UIAwesome\Html\Form\Option::tag()->value('scl')->content('Santiago'))
+     *     ->getContent();
+     * ```
+     *
+     * @return string Content with the appended options rendered in place.
+     */
+    #[Override]
+    public function getContent(): string
+    {
+        return $this->renderChildren($this->selectedValues);
+    }
 
     /**
      * Appends an `<option>` element to the option group.
+     *
+     * Usage example:
+     * ```php
+     * $optgroup = \UIAwesome\Html\Form\Optgroup::tag()
+     *     ->option(\UIAwesome\Html\Form\Option::tag()->value('scl')->content('Santiago'));
+     * ```
      *
      * @param Option $option Option element instance.
      *
@@ -36,7 +71,44 @@ final class Optgroup extends BaseBlock
      */
     public function option(Option $option): static
     {
-        return $this->html($option, "\n");
+        return $this->appendChildren($option);
+    }
+
+    /**
+     * Appends multiple `<option>` elements to the option group.
+     *
+     * Usage example:
+     * ```php
+     * $optgroup = \UIAwesome\Html\Form\Optgroup::tag()->options(
+     *     \UIAwesome\Html\Form\Option::tag()->value('scl')->content('Santiago'),
+     *     \UIAwesome\Html\Form\Option::tag()->value('ccp')->content('Concepcion'),
+     * );
+     * ```
+     *
+     * @param Option ...$options Option element instances.
+     *
+     * @return static New instance with the appended options.
+     */
+    public function options(Option ...$options): static
+    {
+        return $this->appendChildren(...$options);
+    }
+
+    /**
+     * Sets the normalized selected values received from the parent select.
+     *
+     * @param string[] $values Normalized selected values.
+     *
+     * @return static New instance with the updated selected values.
+     *
+     * @internal
+     */
+    public function selectedValues(array $values): static
+    {
+        $new = clone $this;
+        $new->selectedValues = $values;
+
+        return $new;
     }
 
     /**

--- a/src/Form/Option.php
+++ b/src/Form/Option.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Form;
 
 use UIAwesome\Html\Attribute\{CanBeDisabled, CanBeSelected, HasLabel, HasValue};
+use UIAwesome\Html\Attribute\Values\ElementAttribute;
 use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Form\Values\SelectTag;
+use UIAwesome\Html\Helper\Enum;
+
+use function in_array;
 
 /**
  * Renders the HTML `<option>` element for selectable options.
@@ -28,6 +32,22 @@ final class Option extends BaseBlock
     use CanBeSelected;
     use HasLabel;
     use HasValue;
+
+    /**
+     * Resolves the `selected` attribute against the values selected by the parent element.
+     *
+     * @param string[] $values Normalized selected values.
+     *
+     * @return static New instance with the resolved `selected` attribute.
+     *
+     * @internal
+     */
+    public function selectedValues(array $values): static
+    {
+        $value = $this->getAttribute(ElementAttribute::VALUE);
+
+        return $this->selected($value !== null && in_array(Enum::normalizeStringValue($value), $values, true));
+    }
 
     /**
      * Returns the tag enumeration for the `<option>` element.

--- a/src/Form/Option.php
+++ b/src/Form/Option.php
@@ -10,7 +10,13 @@ use UIAwesome\Html\Core\Element\BaseBlock;
 use UIAwesome\Html\Form\Values\SelectTag;
 use UIAwesome\Html\Helper\Enum;
 
+use function array_filter;
+use function explode;
+use function html_entity_decode;
+use function implode;
 use function in_array;
+use function str_replace;
+use function strip_tags;
 
 /**
  * Renders the HTML `<option>` element for selectable options.
@@ -44,9 +50,7 @@ final class Option extends BaseBlock
      */
     public function selectedValues(array $values): static
     {
-        $value = $this->getAttribute(ElementAttribute::VALUE);
-
-        return $this->selected($value !== null && in_array(Enum::normalizeStringValue($value), $values, true));
+        return $this->selected(in_array($this->submittedValue(), $values, true));
     }
 
     /**
@@ -57,5 +61,29 @@ final class Option extends BaseBlock
     protected function getTag(): SelectTag
     {
         return SelectTag::OPTION;
+    }
+
+    /**
+     * Returns the value the browser submits for this option.
+     *
+     * Falls back to the option text when the `value` attribute is absent, so selection matching agrees with what the
+     * browser would submit. The text is the markup-free content with ASCII whitespace stripped and collapsed.
+     *
+     * @return string Submitted value.
+     *
+     * @see https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-value
+     */
+    private function submittedValue(): string
+    {
+        $value = $this->getAttribute(ElementAttribute::VALUE);
+
+        if ($value !== null) {
+            return Enum::normalizeStringValue($value);
+        }
+
+        $text = html_entity_decode(strip_tags($this->getContent()), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $words = explode(' ', str_replace(["\t", "\n", "\f", "\r"], ' ', $text));
+
+        return implode(' ', array_filter($words, static fn(string $word): bool => $word !== ''));
     }
 }

--- a/src/Form/RadioList.php
+++ b/src/Form/RadioList.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Form;
+
+/**
+ * Renders a list of `<input type="radio">` controls sharing one name.
+ *
+ * Every item input keeps the plain list name so the browser submits a single value.
+ *
+ * Usage example:
+ * ```php
+ * echo \UIAwesome\Html\Form\RadioList::tag()
+ *     ->checked('yes')
+ *     ->id('answer')
+ *     ->items(
+ *         \UIAwesome\Html\Form\ChoiceItem::tag()->value('yes')->label('Yes'),
+ *         \UIAwesome\Html\Form\ChoiceItem::tag()->value('no')->label('No'),
+ *     )
+ *     ->name('answer')
+ *     ->render();
+ * ```
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/radio
+ * {@see AbstractChoiceList} for the base implementation.
+ */
+final class RadioList extends AbstractChoiceList
+{
+    /**
+     * Creates the atomic input used for each item.
+     *
+     * @return InputRadio Radio input element instance.
+     */
+    protected function createInput(): InputRadio
+    {
+        return InputRadio::tag();
+    }
+
+    /**
+     * Returns whether item names use array notation.
+     *
+     * @return false Always `false`, so every item input keeps the plain list name.
+     */
+    protected function usesArrayName(): false
+    {
+        return false;
+    }
+}

--- a/src/Form/Select.php
+++ b/src/Form/Select.php
@@ -17,6 +17,8 @@ use UIAwesome\Html\Helper\{Enum, Validator};
 use UIAwesome\Html\Interop\Block;
 use UnitEnum;
 
+use function count;
+use function implode;
 use function is_array;
 
 /**
@@ -261,7 +263,8 @@ final class Select extends BaseBlock implements FormControlInterface
      * ```
      *
      * @param array<mixed>|bool|float|int|string|Stringable|UnitEnum|null $value Selected value or values. Must be an
-     * `array` or `null` when `multiple` is `true`; the constraint is enforced on render.
+     * `array` or `null` when `multiple` is `true`, and must not hold more than one value otherwise; the constraint is
+     * enforced on render.
      *
      * @return static New instance with the updated selected value.
      */
@@ -289,26 +292,15 @@ final class Select extends BaseBlock implements FormControlInterface
     /**
      * Validates the selected value and renders the `<select>` element.
      *
-     * @throws InvalidArgumentException if a non-`null` scalar value is selected while `multiple` is `true`.
+     * @throws InvalidArgumentException if the selected value does not match the `multiple` attribute.
      *
      * @return string Rendered HTML for the `<select>` element.
      */
     #[Override]
     protected function run(): string
     {
-        if (
-            $this->isBeginExecuted() === false
-            && $this->value !== null
-            && $this->getAttribute(Attribute::MULTIPLE) === true
-            && is_array($this->value) === false
-        ) {
-            throw new InvalidArgumentException(
-                Message::ATTRIBUTE_INVALID_VALUE->getMessage(
-                    Enum::normalizeStringValue($this->value),
-                    ElementAttribute::VALUE->value,
-                    'array when "multiple" is true',
-                ),
-            );
+        if ($this->isBeginExecuted() === false) {
+            $this->validateValue();
         }
 
         return parent::run();
@@ -330,5 +322,43 @@ final class Select extends BaseBlock implements FormControlInterface
         }
 
         return Enum::normalizeStringArray(is_array($this->value) ? $this->value : [$this->value]);
+    }
+
+    /**
+     * Validates the selected value against the `multiple` attribute.
+     *
+     * A `multiple` select carries an array of values, while a single select carries at most one, since the browser
+     * submits only one value and would discard the rest.
+     *
+     * @throws InvalidArgumentException if the selected value does not match the `multiple` attribute.
+     */
+    private function validateValue(): void
+    {
+        if ($this->value === null) {
+            return;
+        }
+
+        $isMultiple = $this->getAttribute(Attribute::MULTIPLE) === true;
+        $isArray = is_array($this->value);
+
+        if ($isMultiple && $isArray === false) {
+            throw new InvalidArgumentException(
+                Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                    Enum::normalizeStringValue($this->value),
+                    ElementAttribute::VALUE->value,
+                    'array when "multiple" is true',
+                ),
+            );
+        }
+
+        if ($isMultiple === false && $isArray && count($this->value) > 1) {
+            throw new InvalidArgumentException(
+                Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                    implode(', ', Enum::normalizeStringArray($this->value)),
+                    ElementAttribute::VALUE->value,
+                    'single value unless "multiple" is true',
+                ),
+            );
+        }
     }
 }

--- a/src/Form/Select.php
+++ b/src/Form/Select.php
@@ -5,15 +5,19 @@ declare(strict_types=1);
 namespace UIAwesome\Html\Form;
 
 use InvalidArgumentException;
+use Override;
 use Stringable;
 use UIAwesome\Html\Attribute\{CanBeDisabled, HasName};
 use UIAwesome\Html\Attribute\Exception\Message;
-use UIAwesome\Html\Attribute\Values\Attribute;
+use UIAwesome\Html\Attribute\Values\{Attribute, ElementAttribute};
 use UIAwesome\Html\Contracts\Form\FormControlInterface;
 use UIAwesome\Html\Core\Element\BaseBlock;
+use UIAwesome\Html\Form\Mixin\HasSelectableChildren;
 use UIAwesome\Html\Helper\{Enum, Validator};
 use UIAwesome\Html\Interop\Block;
 use UnitEnum;
+
+use function is_array;
 
 /**
  * Renders the HTML `<select>` element for choosing one or more options.
@@ -34,6 +38,18 @@ final class Select extends BaseBlock implements FormControlInterface
 {
     use CanBeDisabled;
     use HasName;
+    use HasSelectableChildren;
+
+    /**
+     * Selected value or values.
+     *
+     * @var array<mixed>|bool|float|int|string|Stringable|UnitEnum|null
+     */
+    private array|bool|float|int|string|Stringable|UnitEnum|null $value = null;
+    /**
+     * Whether {@see value()} was called, distinguishing an unset selection from a `null` selection.
+     */
+    private bool $valueConfigured = false;
 
     /**
      * Sets the `autocomplete` attribute.
@@ -75,6 +91,27 @@ final class Select extends BaseBlock implements FormControlInterface
     }
 
     /**
+     * Returns the content with every appended option and option group rendered in place.
+     *
+     * Children are rendered on access, so the value configured through {@see value()} is applied to the current
+     * option instances.
+     *
+     * Usage example:
+     * ```php
+     * $html = \UIAwesome\Html\Form\Select::tag()
+     *     ->option(\UIAwesome\Html\Form\Option::tag()->value('dog')->content('Dog'))
+     *     ->getContent();
+     * ```
+     *
+     * @return string Content with the appended children rendered in place.
+     */
+    #[Override]
+    public function getContent(): string
+    {
+        return $this->renderChildren($this->selectedValues());
+    }
+
+    /**
      * Sets the `multiple` attribute.
      *
      * Usage example:
@@ -96,17 +133,33 @@ final class Select extends BaseBlock implements FormControlInterface
     /**
      * Appends an `<optgroup>` element to the select.
      *
+     * Usage example:
+     * ```php
+     * $select = \UIAwesome\Html\Form\Select::tag()
+     *     ->optgroup(
+     *         \UIAwesome\Html\Form\Optgroup::tag()
+     *             ->label('Pets')
+     *             ->option(\UIAwesome\Html\Form\Option::tag()->value('dog')->content('Dog')),
+     *     );
+     * ```
+     *
      * @param Optgroup $optgroup Optgroup element instance.
      *
      * @return static New instance with the appended optgroup.
      */
     public function optgroup(Optgroup $optgroup): static
     {
-        return $this->html($optgroup, "\n");
+        return $this->appendChildren($optgroup);
     }
 
     /**
      * Appends an `<option>` element to the select.
+     *
+     * Usage example:
+     * ```php
+     * $select = \UIAwesome\Html\Form\Select::tag()
+     *     ->option(\UIAwesome\Html\Form\Option::tag()->value('dog')->content('Dog'));
+     * ```
      *
      * @param Option $option Option element instance.
      *
@@ -114,34 +167,28 @@ final class Select extends BaseBlock implements FormControlInterface
      */
     public function option(Option $option): static
     {
-        return $this->html($option, "\n");
+        return $this->appendChildren($option);
     }
 
     /**
-     * Appends multiple `<option>` elements to the select from value-label pairs.
+     * Appends multiple `<option>` elements to the select.
      *
      * Usage example:
      * ```php
      * $select = \UIAwesome\Html\Form\Select::tag()->options(
-     *     ['dog', 'Dog'],
-     *     ['cat', 'Cat'],
-     *     ['hamster', 'Hamster'],
+     *     \UIAwesome\Html\Form\Option::tag()->value('dog')->content('Dog'),
+     *     \UIAwesome\Html\Form\Option::tag()->value('cat')->content('Cat'),
+     *     \UIAwesome\Html\Form\Option::tag()->value('hamster')->content('Hamster'),
      * );
      * ```
      *
-     * @param array{0: string, 1: string|Stringable} ...$items Arrays of '[value, label]' pairs.
+     * @param Option ...$options Option element instances.
      *
      * @return static New instance with the appended options.
      */
-    public function options(array ...$items): static
+    public function options(Option ...$options): static
     {
-        $select = $this;
-
-        foreach ($items as $item) {
-            $select = $select->option(Option::tag()->value($item[0])->content($item[1]));
-        }
-
-        return $select;
+        return $this->appendChildren(...$options);
     }
 
     /**
@@ -199,6 +246,35 @@ final class Select extends BaseBlock implements FormControlInterface
     }
 
     /**
+     * Sets the value or values used to select child options.
+     *
+     * The selected value is rendering state and is never serialized as a `value` attribute on the `<select>`.
+     *
+     * Usage example:
+     * ```php
+     * $select = \UIAwesome\Html\Form\Select::tag()
+     *     ->value('cat')
+     *     ->options(
+     *         \UIAwesome\Html\Form\Option::tag()->value('dog')->content('Dog'),
+     *         \UIAwesome\Html\Form\Option::tag()->value('cat')->content('Cat'),
+     *     );
+     * ```
+     *
+     * @param array<mixed>|bool|float|int|string|Stringable|UnitEnum|null $value Selected value or values. Must be an
+     * `array` or `null` when `multiple` is `true`; the constraint is enforced on render.
+     *
+     * @return static New instance with the updated selected value.
+     */
+    public function value(array|bool|float|int|string|Stringable|UnitEnum|null $value): static
+    {
+        $new = clone $this;
+        $new->value = $value;
+        $new->valueConfigured = true;
+
+        return $new;
+    }
+
+    /**
      * Returns the tag enumeration for the `<select>` element.
      *
      * @return Block Tag enumeration instance for `<select>`.
@@ -208,5 +284,51 @@ final class Select extends BaseBlock implements FormControlInterface
     protected function getTag(): Block
     {
         return Block::SELECT;
+    }
+
+    /**
+     * Validates the selected value and renders the `<select>` element.
+     *
+     * @throws InvalidArgumentException if a non-`null` scalar value is selected while `multiple` is `true`.
+     *
+     * @return string Rendered HTML for the `<select>` element.
+     */
+    #[Override]
+    protected function run(): string
+    {
+        if (
+            $this->isBeginExecuted() === false
+            && $this->value !== null
+            && $this->getAttribute(Attribute::MULTIPLE) === true
+            && is_array($this->value) === false
+        ) {
+            throw new InvalidArgumentException(
+                Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                    Enum::normalizeStringValue($this->value),
+                    ElementAttribute::VALUE->value,
+                    'array when "multiple" is true',
+                ),
+            );
+        }
+
+        return parent::run();
+    }
+
+    /**
+     * Returns the normalized selected values, or `null` when no selection was configured.
+     *
+     * @return string[]|null Normalized selected values.
+     */
+    private function selectedValues(): array|null
+    {
+        if ($this->valueConfigured === false) {
+            return null;
+        }
+
+        if ($this->value === null) {
+            return [];
+        }
+
+        return Enum::normalizeStringArray(is_array($this->value) ? $this->value : [$this->value]);
     }
 }

--- a/tests/Form/CheckboxListTest.php
+++ b/tests/Form/CheckboxListTest.php
@@ -283,6 +283,102 @@ final class CheckboxListTest extends TestCase
         );
     }
 
+    public function testRenderWithCheckedFalse(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice[]" type="checkbox" value="1">
+            <label for="choices-0">One</label>
+            <input id="choices-1" name="choice[]" type="checkbox" value="2">
+            <label for="choices-1">Two</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->checked(false)
+                ->id('choices')
+                ->items(
+                    ChoiceItem::tag()->label('One')->value(1),
+                    ChoiceItem::tag()->label('Two')->value(2),
+                )
+                ->name('choice')
+                ->render(),
+            'No item must be checked.',
+        );
+    }
+
+    public function testRenderWithCheckedNull(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice[]" type="checkbox" value="1">
+            <label for="choices-0">One</label>
+            <input id="choices-1" name="choice[]" type="checkbox" value="2">
+            <label for="choices-1">Two</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->checked(null)
+                ->id('choices')
+                ->items(
+                    ChoiceItem::tag()->label('One')->value(1),
+                    ChoiceItem::tag()->label('Two')->value(2),
+                )
+                ->name('choice')
+                ->render(),
+            'No item must be checked.',
+        );
+    }
+
+    public function testRenderWithCheckedTrue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice[]" type="checkbox" value="1" checked>
+            <label for="choices-0">One</label>
+            <input id="choices-1" name="choice[]" type="checkbox" value="2" checked>
+            <label for="choices-1">Two</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->checked(true)
+                ->id('choices')
+                ->items(
+                    ChoiceItem::tag()->label('One')->value(1),
+                    ChoiceItem::tag()->label('Two')->value(2),
+                )
+                ->name('choice')
+                ->render(),
+            'Every item must be checked.',
+        );
+    }
+
+    public function testRenderWithCheckedUsingArray(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice[]" type="checkbox" value="1" checked>
+            <label for="choices-0">One</label>
+            <input id="choices-1" name="choice[]" type="checkbox" value="2">
+            <label for="choices-1">Two</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->checked([1])
+                ->id('choices')
+                ->items(
+                    ChoiceItem::tag()->label('One')->value(1),
+                    ChoiceItem::tag()->label('Two')->value(2),
+                )
+                ->name('choice')
+                ->render(),
+            'Matching item must be checked.',
+        );
+    }
+
     public function testRenderWithCheckedUsingEnum(): void
     {
         self::assertSame(
@@ -298,7 +394,7 @@ final class CheckboxListTest extends TestCase
                 ->items(ChoiceItem::tag()->label('Value')->value('value'))
                 ->name('choice')
                 ->render(),
-            'Enum value must check its normalized item value.',
+            'Matching item must be checked.',
         );
     }
 

--- a/tests/Form/CheckboxListTest.php
+++ b/tests/Form/CheckboxListTest.php
@@ -1,0 +1,1178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Form;
+
+use InvalidArgumentException;
+use PHPForge\Support\Stub\BackedString;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{
+    Aria,
+    ContentEditable,
+    Data,
+    Direction,
+    Draggable,
+    GlobalAttribute,
+    Language,
+    Role,
+    Translate,
+};
+use UIAwesome\Html\Form\{CheckboxList, ChoiceItem};
+use UIAwesome\Html\Helper\Enum;
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see CheckboxList} rendering and attribute behavior.
+ */
+#[Group('form')]
+final class CheckboxListTest extends TestCase
+{
+    public function testContentEncodesValues(): void
+    {
+        self::assertSame(
+            '&lt;value&gt;',
+            CheckboxList::tag()
+                ->content('<value>')
+                ->getContent(),
+            'Content must be HTML-encoded.',
+        );
+    }
+
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'value',
+            CheckboxList::tag()->getAttribute('class', 'value'),
+            'Default fallback must be returned.',
+        );
+    }
+
+    public function testGetAttributesReturnsAssignedAttributes(): void
+    {
+        self::assertSame(
+            ['class' => 'value'],
+            CheckboxList::tag()
+                ->addAttribute('class', 'value')
+                ->getAttributes(),
+            'Assigned attributes must be returned.',
+        );
+    }
+
+    public function testHtmlDoesNotEncodeValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <value>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->html('<value>')
+                ->render(),
+            'Raw HTML content must be applied.',
+        );
+    }
+
+    public function testItemsReplaceExistingItems(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <input type="checkbox" value="2">
+            <label>Two</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->items(ChoiceItem::tag()->label('Two')->value(2))
+                ->render(),
+            'Items must replace existing items when set.',
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div accesskey="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->accesskey('value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'accesskey' must be serialized.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div aria-label="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addAriaAttribute('label', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'ARIA attribute must be added.',
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div aria-label="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addAriaAttribute(Aria::LABEL, 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'ARIA attribute must be added.',
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div data-value="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addDataAttribute('value', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Data attribute must be added.',
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div data-value="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addDataAttribute(Data::VALUE, 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Data attribute must be added.',
+        );
+    }
+
+    public function testRenderWithAddEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div onclick="alert(&apos;Clicked!&apos;)">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Event handler must be added.',
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div aria-controls="value" aria-label="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->ariaAttributes(
+                    [
+                        'controls' => 'value',
+                        'label' => 'value',
+                    ],
+                )
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'ARIA attribute map must be applied.',
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->attributes(['class' => 'value'])
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Attribute map must be applied.',
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div autofocus>
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->autofocus(true)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'autofocus' must be serialized.",
+        );
+    }
+
+    public function testRenderWithBeginEnd(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            Content
+            </div>
+            HTML,
+            CheckboxList::tag()->begin() . 'Content' . CheckboxList::end(),
+            'begin/end must produce a complete element.',
+        );
+    }
+
+    public function testRenderWithChecked(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice[]" type="checkbox" value="value" checked>
+            <label for="choices-0">Value</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->checked('value')
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('Value')->value('value'))
+                ->name('choice')
+                ->render(),
+            'Matching item must be checked.',
+        );
+    }
+
+    public function testRenderWithCheckedUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice[]" type="checkbox" value="value" checked>
+            <label for="choices-0">Value</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->checked(BackedString::VALUE)
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('Value')->value('value'))
+                ->name('choice')
+                ->render(),
+            'Enum value must check its normalized item value.',
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->class('value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'class' must be serialized.",
+        );
+    }
+
+    public function testRenderWithClassUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->class(BackedString::VALUE)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'class' must be serialized.",
+        );
+    }
+
+    public function testRenderWithContent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            Pick one:<input id="choices-0" name="choice[]" type="checkbox" value="1">
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->content('Pick one:')
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            'Container content must precede the rendered items.',
+        );
+    }
+
+    public function testRenderWithContentEditable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div contenteditable="true">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->contentEditable(true)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'contentEditable' must be serialized.",
+        );
+    }
+
+    public function testRenderWithContentEditableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div contenteditable="true">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->contentEditable(ContentEditable::TRUE)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'contentEditable' must be serialized.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div data-value="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->dataAttributes(['value' => 'value'])
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Data attribute map must be applied.',
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="default-class">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag(['class' => 'default-class'])
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Constructor configuration must be applied.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="default-class">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Default provider must contribute attributes.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div dir="ltr">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->dir('ltr')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'dir' must be serialized.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div dir="ltr">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->dir(Direction::LTR)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'dir' must be serialized.",
+        );
+    }
+
+    public function testRenderWithDraggable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div draggable="true">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->draggable(true)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'draggable' must be serialized.",
+        );
+    }
+
+    public function testRenderWithDraggableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div draggable="true">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->draggable(Draggable::TRUE)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'draggable' must be serialized.",
+        );
+    }
+
+    public function testRenderWithEnclosedLabels(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <label for="choices-0"><input id="choices-0" name="choice[]" type="checkbox" value="1" checked>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->checked(1)
+                ->enclosedByLabel()
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            'Item input and text must be enclosed by the label.',
+        );
+    }
+
+    public function testRenderWithEnclosedLabelsDisabled(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice[]" type="checkbox" value="1" checked>
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->checked(1)
+                ->enclosedByLabel()
+                ->enclosedByLabel(false)
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            'Disabling enclosure must restore sibling label rendering.',
+        );
+    }
+
+    public function testRenderWithEvents(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div onfocus="handleFocus()" onblur="handleBlur()">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->events(
+                    [
+                        'focus' => 'handleFocus()',
+                        'blur' => 'handleBlur()',
+                    ],
+                )
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Event handler map must be applied.',
+        );
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div hidden>
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->hidden(true)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'hidden' must be serialized.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="value">
+            <input id="value-0" type="checkbox" value="1">
+            <label for="value-0">One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->id('value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'id' must be serialized.",
+        );
+    }
+
+    public function testRenderWithItemAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input class="choice" id="choices-0" name="choice[]" type="checkbox" value="1" data-state="ready">
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->id('choices')
+                ->itemAttributes(['class' => 'choice'])
+                ->itemAttributes(['data-state' => 'ready'])
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            'Item attributes must merge and apply to every item input.',
+        );
+    }
+
+    public function testRenderWithItems(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice[]" type="checkbox" value="1">
+            <label for="choices-0">One</label>
+            <input id="choices-1" name="choice[]" type="checkbox" value="2">
+            <label for="choices-1">Two</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->id('choices')
+                ->items(
+                    ChoiceItem::tag()->label('One')->value(1),
+                    ChoiceItem::tag()->label('Two')->value(2),
+                )
+                ->name('choice')
+                ->render(),
+            'Items must be rendered in order with sequential identifiers.',
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div lang="en">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->lang('en')
+                ->render(),
+            "'lang' must be serialized.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div lang="en">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->lang(Language::ENGLISH)
+                ->render(),
+            "'lang' must be serialized.",
+        );
+    }
+
+    public function testRenderWithMicroData(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div itemid="https://example.com/item" itemprop="name" itemref="info" itemscope itemtype="https://schema.org/Thing">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->itemId('https://example.com/item')
+                ->itemProp('name')
+                ->itemRef('info')
+                ->itemScope(true)
+                ->itemType('https://schema.org/Thing')
+                ->render(),
+            'Microdata attributes must be serialized.',
+        );
+    }
+
+    public function testRenderWithName(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice[]" type="checkbox" value="1">
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            "'name' must be transferred to the item inputs as 'choice[]'.",
+        );
+    }
+
+    public function testRenderWithNamedItems(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice[]" type="checkbox" value="1">
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->id('choices')
+                ->items(first: ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            'Named variadic items must be normalized to sequential item indexes.',
+        );
+    }
+
+    public function testRenderWithoutIdentifiers(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="1">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addAttribute('id', 1)
+                ->addAttribute('name', 1)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->uncheckedValue('0')
+                ->render(),
+            'Non-string identifiers must not be transferred to item inputs.',
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addAriaAttribute('label', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->removeAriaAttribute('label')
+                ->render(),
+            'ARIA attribute must be removed.',
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addAttribute('class', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->removeAttribute('class')
+                ->render(),
+            'Attribute must be removed.',
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addDataAttribute('value', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->removeDataAttribute('value')
+                ->render(),
+            'Data attribute must be removed.',
+        );
+    }
+
+    public function testRenderWithRemoveEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->removeEvent('click')
+                ->render(),
+            'Event handler must be removed.',
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div role="banner">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->role('banner')
+                ->render(),
+            "'role' must be serialized.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div role="banner">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->role(Role::BANNER)
+                ->render(),
+            "'role' must be serialized.",
+        );
+    }
+
+    public function testRenderWithSetAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addAttribute('class', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Arbitrary attribute must be added.',
+        );
+    }
+
+    public function testRenderWithSetAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div title="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addAttribute(GlobalAttribute::TITLE, 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Arbitrary attribute must be added.',
+        );
+    }
+
+    public function testRenderWithSpellcheck(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div spellcheck="true">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->spellcheck(true)
+                ->render(),
+            "'spellcheck' must be serialized.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div style='value'>
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->style('value')
+                ->render(),
+            "'style' must be serialized.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div tabindex="3">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->tabIndex(3)
+                ->render(),
+            "'tabindex' must be serialized.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="text-muted">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->addThemeProvider('muted', DefaultThemeProvider::class)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Theme provider must contribute classes.',
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div title="value">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->title('value')
+                ->render(),
+            "'title' must be serialized.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            </div>
+            HTML,
+            (string) CheckboxList::tag(),
+            'Casting to string must produce HTML.',
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div translate="no">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->translate(false)
+                ->render(),
+            "'translate' must be serialized.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div translate="no">
+            <input type="checkbox" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->translate(Translate::NO)
+                ->render(),
+            "'translate' must be serialized.",
+        );
+    }
+
+    public function testRenderWithUncheckedValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input name="choice" type="hidden" value="0">
+            <input id="choices-0" name="choice[]" type="checkbox" value="1">
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->uncheckedValue('0')
+                ->render(),
+            'Unchecked value must render a hidden input before the items.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAttribute(): void
+    {
+        $checkboxList = CheckboxList::tag();
+
+        self::assertNotSame(
+            $checkboxList,
+            $checkboxList->checked(null),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $checkboxList,
+            $checkboxList->enclosedByLabel(),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $checkboxList,
+            $checkboxList->itemAttributes([]),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $checkboxList,
+            $checkboxList->items(ChoiceItem::tag()),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $checkboxList,
+            $checkboxList->uncheckedValue(null),
+            'New instance must be returned (immutability).',
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingContentEditable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::CONTENTEDITABLE->value,
+                implode("', '", Enum::normalizeStringArray(ContentEditable::cases())),
+            ),
+        );
+
+        CheckboxList::tag()->contentEditable('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingDir(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::DIR->value,
+                implode("', '", Enum::normalizeStringArray(Direction::cases())),
+            ),
+        );
+
+        CheckboxList::tag()->dir('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingDraggable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::DRAGGABLE->value,
+                implode("', '", Enum::normalizeStringArray(Draggable::cases())),
+            ),
+        );
+
+        CheckboxList::tag()->draggable('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingLang(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::LANG->value,
+                implode("', '", Enum::normalizeStringArray(Language::cases())),
+            ),
+        );
+
+        CheckboxList::tag()->lang('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingRole(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::ROLE->value,
+                implode("', '", Enum::normalizeStringArray(Role::cases())),
+            ),
+        );
+
+        CheckboxList::tag()->role('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingTabindex(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            \UIAwesome\Html\Attribute\Exception\Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                '-2',
+                GlobalAttribute::TABINDEX->value,
+                'value >= -1',
+            ),
+        );
+
+        CheckboxList::tag()->tabIndex(-2);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingTranslate(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::TRANSLATE->value,
+                implode("', '", Enum::normalizeStringArray(Translate::cases())),
+            ),
+        );
+
+        CheckboxList::tag()->translate('invalid-value');
+    }
+}

--- a/tests/Form/CheckboxListTest.php
+++ b/tests/Form/CheckboxListTest.php
@@ -397,6 +397,25 @@ final class CheckboxListTest extends TestCase
         );
     }
 
+    public function testRenderWithCheckedUsingDefaultSubmittedValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice[]" type="checkbox" checked>
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->checked('on')
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One'))
+                ->name('choice')
+                ->render(),
+            'Item without a value must match the submitted `on` value.',
+        );
+    }
+
     public function testRenderWithCheckedUsingEnum(): void
     {
         self::assertSame(

--- a/tests/Form/CheckboxListTest.php
+++ b/tests/Form/CheckboxListTest.php
@@ -1204,7 +1204,7 @@ final class CheckboxListTest extends TestCase
                 ->name('choice')
                 ->uncheckedValue('0')
                 ->render(),
-            'Unchecked value must render a hidden input before the items.',
+            'Fallback must keep the plain name so a checked item overwrites it.',
         );
     }
 

--- a/tests/Form/CheckboxListTest.php
+++ b/tests/Form/CheckboxListTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PHPForge\Support\Stub\BackedString;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Stringable;
 use UIAwesome\Html\Attribute\Values\{
     Aria,
     ContentEditable,
@@ -699,6 +700,53 @@ final class CheckboxListTest extends TestCase
         );
     }
 
+    public function testRenderWithIdentifiersUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="value">
+            <input name="value" type="hidden" value="0">
+            <input id="value-0" name="value[]" type="checkbox" value="1">
+            <label for="value-0">One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->id(BackedString::VALUE)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name(BackedString::VALUE)
+                ->uncheckedValue('0')
+                ->render(),
+            'Enum identifiers must be transferred to the item inputs.',
+        );
+    }
+
+    public function testRenderWithIdentifiersUsingStringable(): void
+    {
+        $identifier = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'choice';
+            }
+        };
+
+        self::assertSame(
+            <<<HTML
+            <div id="choice">
+            <input name="choice" type="hidden" value="0">
+            <input id="choice-0" name="choice[]" type="checkbox" value="1">
+            <label for="choice-0">One</label>
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->id($identifier)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name($identifier)
+                ->uncheckedValue('0')
+                ->render(),
+            'Stringable identifiers must be transferred to the item inputs.',
+        );
+    }
+
     public function testRenderWithItemAttributes(): void
     {
         self::assertSame(
@@ -848,7 +896,7 @@ final class CheckboxListTest extends TestCase
                 ->items(ChoiceItem::tag()->label('One')->value(1))
                 ->uncheckedValue('0')
                 ->render(),
-            'Non-string identifiers must not be transferred to item inputs.',
+            'Unsupported identifier types must not be transferred to item inputs.',
         );
     }
 

--- a/tests/Form/CheckboxListTest.php
+++ b/tests/Form/CheckboxListTest.php
@@ -265,6 +265,23 @@ final class CheckboxListTest extends TestCase
         );
     }
 
+    public function testRenderWithBeginEndOmittingName(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="box" id="choices">
+            Content
+            </div>
+            HTML,
+            CheckboxList::tag()
+                ->class('box')
+                ->id('choices')
+                ->name('choice')
+                ->begin() . 'Content' . CheckboxList::end(),
+            'Container must not serialize the form control name.',
+        );
+    }
+
     public function testRenderWithChecked(): void
     {
         self::assertSame(

--- a/tests/Form/ChoiceItemTest.php
+++ b/tests/Form/ChoiceItemTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Form;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Form\{ChoiceItem, InputCheckbox, InputRadio};
+
+/**
+ * Unit tests for {@see ChoiceItem} rendering and attribute behavior.
+ */
+#[Group('form')]
+final class ChoiceItemTest extends TestCase
+{
+    public function testRenderWithEnclosedLabel(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <label class="choice-label" for="choice"><input id="choice" name="choices[]" type="checkbox" value="1" checked>One</label>
+            HTML,
+            ChoiceItem::tag()
+                ->label('One')
+                ->labelClass('choice-label')
+                ->value(1)
+                ->render(InputCheckbox::tag(), [], 'choice', 'choices[]', [1], true),
+            'Enclosed label must contain the input and encoded label text.',
+        );
+    }
+
+    public function testRenderWithMergedLabelClasses(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input id="choice" name="choice" type="radio" value="yes">
+            <label class="base additional" for="choice">Yes</label>
+            HTML,
+            ChoiceItem::tag()
+                ->label('Yes')
+                ->labelClass('base')
+                ->labelClass('additional')
+                ->value('yes')
+                ->render(InputRadio::tag(), [], 'choice', 'choice', null, false),
+            'Label classes must merge by default.',
+        );
+    }
+
+    public function testRenderWithSeparateLabel(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <input class="choice" id="choice" name="choice" type="radio" value="yes">
+            <label class="replacement" for="choice">Yes &amp; continue</label>
+            HTML,
+            ChoiceItem::tag()
+                ->label('Yes & continue')
+                ->labelAttributes(['class' => 'base', 'data-item' => 'yes'])
+                ->labelClass('ignored')
+                ->labelClass('replacement', true)
+                ->labelAttributes(['data-item' => null])
+                ->value('yes')
+                ->render(InputRadio::tag(), ['class' => 'choice'], 'choice', 'choice', 'no', false),
+            'Separate label must preserve the item value and configured attributes.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAttribute(): void
+    {
+        $choiceItem = ChoiceItem::tag();
+
+        self::assertNotSame(
+            $choiceItem,
+            $choiceItem->label(''),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $choiceItem,
+            $choiceItem->labelAttributes([]),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $choiceItem,
+            $choiceItem->labelClass(''),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $choiceItem,
+            $choiceItem->value(null),
+            'New instance must be returned (immutability).',
+        );
+    }
+}

--- a/tests/Form/OptgroupTest.php
+++ b/tests/Form/OptgroupTest.php
@@ -504,6 +504,49 @@ final class OptgroupTest extends TestCase
         );
     }
 
+    public function testRenderWithOptionPreservesContentOrder(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <optgroup>
+            Before<option value="1">
+            Santiago
+            </option>
+            After
+            </optgroup>
+            HTML,
+            Optgroup::tag()
+                ->content('Before')
+                ->option(Option::tag()->value('1')->content('Santiago'))
+                ->content('After')
+                ->render(),
+            'Option must preserve its position relative to other content.',
+        );
+    }
+
+    public function testRenderWithOptions(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <optgroup>
+            <option value="1">
+            Santiago
+            </option>
+            <option value="2">
+            Concepcion
+            </option>
+            </optgroup>
+            HTML,
+            Optgroup::tag()
+                ->options(
+                    Option::tag()->value('1')->content('Santiago'),
+                    Option::tag()->value('2')->content('Concepcion'),
+                )
+                ->render(),
+            'Options collection must be applied.',
+        );
+    }
+
     public function testRenderWithRemoveAriaAttribute(): void
     {
         self::assertSame(
@@ -737,6 +780,16 @@ final class OptgroupTest extends TestCase
         self::assertNotSame(
             $optgroup,
             $optgroup->option(Option::tag()),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $optgroup,
+            $optgroup->options(Option::tag()),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $optgroup,
+            $optgroup->selectedValues([]),
             'New instance must be returned (immutability).',
         );
     }

--- a/tests/Form/RadioListTest.php
+++ b/tests/Form/RadioListTest.php
@@ -265,6 +265,23 @@ final class RadioListTest extends TestCase
         );
     }
 
+    public function testRenderWithBeginEndOmittingName(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="box" id="choices">
+            Content
+            </div>
+            HTML,
+            RadioList::tag()
+                ->class('box')
+                ->id('choices')
+                ->name('choice')
+                ->begin() . 'Content' . RadioList::end(),
+            'Container must not serialize the form control name.',
+        );
+    }
+
     public function testRenderWithChecked(): void
     {
         self::assertSame(

--- a/tests/Form/RadioListTest.php
+++ b/tests/Form/RadioListTest.php
@@ -397,6 +397,25 @@ final class RadioListTest extends TestCase
         );
     }
 
+    public function testRenderWithCheckedUsingDefaultSubmittedValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice" type="radio" checked>
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->checked('on')
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One'))
+                ->name('choice')
+                ->render(),
+            'Item without a value must match the submitted `on` value.',
+        );
+    }
+
     public function testRenderWithCheckedUsingEnum(): void
     {
         self::assertSame(

--- a/tests/Form/RadioListTest.php
+++ b/tests/Form/RadioListTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PHPForge\Support\Stub\BackedString;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Stringable;
 use UIAwesome\Html\Attribute\Values\{
     Aria,
     ContentEditable,
@@ -699,6 +700,53 @@ final class RadioListTest extends TestCase
         );
     }
 
+    public function testRenderWithIdentifiersUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="value">
+            <input name="value" type="hidden" value="0">
+            <input id="value-0" name="value" type="radio" value="1">
+            <label for="value-0">One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->id(BackedString::VALUE)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name(BackedString::VALUE)
+                ->uncheckedValue('0')
+                ->render(),
+            'Enum identifiers must be transferred to the item inputs.',
+        );
+    }
+
+    public function testRenderWithIdentifiersUsingStringable(): void
+    {
+        $identifier = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'choice';
+            }
+        };
+
+        self::assertSame(
+            <<<HTML
+            <div id="choice">
+            <input name="choice" type="hidden" value="0">
+            <input id="choice-0" name="choice" type="radio" value="1">
+            <label for="choice-0">One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->id($identifier)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name($identifier)
+                ->uncheckedValue('0')
+                ->render(),
+            'Stringable identifiers must be transferred to the item inputs.',
+        );
+    }
+
     public function testRenderWithItemAttributes(): void
     {
         self::assertSame(
@@ -848,7 +896,7 @@ final class RadioListTest extends TestCase
                 ->items(ChoiceItem::tag()->label('One')->value(1))
                 ->uncheckedValue('0')
                 ->render(),
-            'Non-string identifiers must not be transferred to item inputs.',
+            'Unsupported identifier types must not be transferred to item inputs.',
         );
     }
 

--- a/tests/Form/RadioListTest.php
+++ b/tests/Form/RadioListTest.php
@@ -1,0 +1,1178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Html\Tests\Form;
+
+use InvalidArgumentException;
+use PHPForge\Support\Stub\BackedString;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Html\Attribute\Values\{
+    Aria,
+    ContentEditable,
+    Data,
+    Direction,
+    Draggable,
+    GlobalAttribute,
+    Language,
+    Role,
+    Translate,
+};
+use UIAwesome\Html\Form\{ChoiceItem, RadioList};
+use UIAwesome\Html\Helper\Enum;
+use UIAwesome\Html\Helper\Exception\Message;
+use UIAwesome\Html\Tests\Support\Stub\{DefaultProvider, DefaultThemeProvider};
+
+/**
+ * Unit tests for {@see RadioList} rendering and attribute behavior.
+ */
+#[Group('form')]
+final class RadioListTest extends TestCase
+{
+    public function testContentEncodesValues(): void
+    {
+        self::assertSame(
+            '&lt;value&gt;',
+            RadioList::tag()
+                ->content('<value>')
+                ->getContent(),
+            'Content must be HTML-encoded.',
+        );
+    }
+
+    public function testGetAttributeReturnsDefaultWhenMissing(): void
+    {
+        self::assertSame(
+            'value',
+            RadioList::tag()->getAttribute('class', 'value'),
+            'Default fallback must be returned.',
+        );
+    }
+
+    public function testGetAttributesReturnsAssignedAttributes(): void
+    {
+        self::assertSame(
+            ['class' => 'value'],
+            RadioList::tag()
+                ->addAttribute('class', 'value')
+                ->getAttributes(),
+            'Assigned attributes must be returned.',
+        );
+    }
+
+    public function testHtmlDoesNotEncodeValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <value>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->html('<value>')
+                ->render(),
+            'Raw HTML content must be applied.',
+        );
+    }
+
+    public function testItemsReplaceExistingItems(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <input type="radio" value="2">
+            <label>Two</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->items(ChoiceItem::tag()->label('Two')->value(2))
+                ->render(),
+            'Items must replace existing items when set.',
+        );
+    }
+
+    public function testRenderWithAccesskey(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div accesskey="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->accesskey('value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'accesskey' must be serialized.",
+        );
+    }
+
+    public function testRenderWithAddAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div aria-label="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addAriaAttribute('label', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'ARIA attribute must be added.',
+        );
+    }
+
+    public function testRenderWithAddAriaAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div aria-label="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addAriaAttribute(Aria::LABEL, 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'ARIA attribute must be added.',
+        );
+    }
+
+    public function testRenderWithAddDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div data-value="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addDataAttribute('value', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Data attribute must be added.',
+        );
+    }
+
+    public function testRenderWithAddDataAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div data-value="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addDataAttribute(Data::VALUE, 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Data attribute must be added.',
+        );
+    }
+
+    public function testRenderWithAddEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div onclick="alert(&apos;Clicked!&apos;)">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Event handler must be added.',
+        );
+    }
+
+    public function testRenderWithAriaAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div aria-controls="value" aria-label="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->ariaAttributes(
+                    [
+                        'controls' => 'value',
+                        'label' => 'value',
+                    ],
+                )
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'ARIA attribute map must be applied.',
+        );
+    }
+
+    public function testRenderWithAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->attributes(['class' => 'value'])
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Attribute map must be applied.',
+        );
+    }
+
+    public function testRenderWithAutofocus(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div autofocus>
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->autofocus(true)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'autofocus' must be serialized.",
+        );
+    }
+
+    public function testRenderWithBeginEnd(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            Content
+            </div>
+            HTML,
+            RadioList::tag()->begin() . 'Content' . RadioList::end(),
+            'begin/end must produce a complete element.',
+        );
+    }
+
+    public function testRenderWithChecked(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice" type="radio" value="value" checked>
+            <label for="choices-0">Value</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->checked('value')
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('Value')->value('value'))
+                ->name('choice')
+                ->render(),
+            'Matching item must be checked.',
+        );
+    }
+
+    public function testRenderWithCheckedUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice" type="radio" value="value" checked>
+            <label for="choices-0">Value</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->checked(BackedString::VALUE)
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('Value')->value('value'))
+                ->name('choice')
+                ->render(),
+            'Enum value must check its normalized item value.',
+        );
+    }
+
+    public function testRenderWithClass(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->class('value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'class' must be serialized.",
+        );
+    }
+
+    public function testRenderWithClassUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->class(BackedString::VALUE)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'class' must be serialized.",
+        );
+    }
+
+    public function testRenderWithContent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            Pick one:<input id="choices-0" name="choice" type="radio" value="1">
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->content('Pick one:')
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            'Container content must precede the rendered items.',
+        );
+    }
+
+    public function testRenderWithContentEditable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div contenteditable="true">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->contentEditable(true)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'contentEditable' must be serialized.",
+        );
+    }
+
+    public function testRenderWithContentEditableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div contenteditable="true">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->contentEditable(ContentEditable::TRUE)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'contentEditable' must be serialized.",
+        );
+    }
+
+    public function testRenderWithDataAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div data-value="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->dataAttributes(['value' => 'value'])
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Data attribute map must be applied.',
+        );
+    }
+
+    public function testRenderWithDefaultConfigurationValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="default-class">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag(['class' => 'default-class'])
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Constructor configuration must be applied.',
+        );
+    }
+
+    public function testRenderWithDefaultProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="default-class">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addDefaultProvider(DefaultProvider::class)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Default provider must contribute attributes.',
+        );
+    }
+
+    public function testRenderWithDir(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div dir="ltr">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->dir('ltr')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'dir' must be serialized.",
+        );
+    }
+
+    public function testRenderWithDirUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div dir="ltr">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->dir(Direction::LTR)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'dir' must be serialized.",
+        );
+    }
+
+    public function testRenderWithDraggable(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div draggable="true">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->draggable(true)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'draggable' must be serialized.",
+        );
+    }
+
+    public function testRenderWithDraggableUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div draggable="true">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->draggable(Draggable::TRUE)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'draggable' must be serialized.",
+        );
+    }
+
+    public function testRenderWithEnclosedLabels(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <label for="choices-0"><input id="choices-0" name="choice" type="radio" value="1" checked>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->checked(1)
+                ->enclosedByLabel()
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            'Item input and text must be enclosed by the label.',
+        );
+    }
+
+    public function testRenderWithEnclosedLabelsDisabled(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice" type="radio" value="1" checked>
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->checked(1)
+                ->enclosedByLabel()
+                ->enclosedByLabel(false)
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            'Disabling enclosure must restore sibling label rendering.',
+        );
+    }
+
+    public function testRenderWithEvents(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div onfocus="handleFocus()" onblur="handleBlur()">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->events(
+                    [
+                        'focus' => 'handleFocus()',
+                        'blur' => 'handleBlur()',
+                    ],
+                )
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Event handler map must be applied.',
+        );
+    }
+
+    public function testRenderWithHidden(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div hidden>
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->hidden(true)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'hidden' must be serialized.",
+        );
+    }
+
+    public function testRenderWithId(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="value">
+            <input id="value-0" type="radio" value="1">
+            <label for="value-0">One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->id('value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            "'id' must be serialized.",
+        );
+    }
+
+    public function testRenderWithItemAttributes(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input class="choice" id="choices-0" name="choice" type="radio" value="1" data-state="ready">
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->id('choices')
+                ->itemAttributes(['class' => 'choice'])
+                ->itemAttributes(['data-state' => 'ready'])
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            'Item attributes must merge and apply to every item input.',
+        );
+    }
+
+    public function testRenderWithItems(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice" type="radio" value="1">
+            <label for="choices-0">One</label>
+            <input id="choices-1" name="choice" type="radio" value="2">
+            <label for="choices-1">Two</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->id('choices')
+                ->items(
+                    ChoiceItem::tag()->label('One')->value(1),
+                    ChoiceItem::tag()->label('Two')->value(2),
+                )
+                ->name('choice')
+                ->render(),
+            'Items must be rendered in order with sequential identifiers.',
+        );
+    }
+
+    public function testRenderWithLang(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div lang="en">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->lang('en')
+                ->render(),
+            "'lang' must be serialized.",
+        );
+    }
+
+    public function testRenderWithLangUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div lang="en">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->lang(Language::ENGLISH)
+                ->render(),
+            "'lang' must be serialized.",
+        );
+    }
+
+    public function testRenderWithMicroData(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div itemid="https://example.com/item" itemprop="name" itemref="info" itemscope itemtype="https://schema.org/Thing">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->itemId('https://example.com/item')
+                ->itemProp('name')
+                ->itemRef('info')
+                ->itemScope(true)
+                ->itemType('https://schema.org/Thing')
+                ->render(),
+            'Microdata attributes must be serialized.',
+        );
+    }
+
+    public function testRenderWithName(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice" type="radio" value="1">
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            "'name' must be transferred to the item inputs as 'choice'.",
+        );
+    }
+
+    public function testRenderWithNamedItems(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice" type="radio" value="1">
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->id('choices')
+                ->items(first: ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->render(),
+            'Named variadic items must be normalized to sequential item indexes.',
+        );
+    }
+
+    public function testRenderWithoutIdentifiers(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="1">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addAttribute('id', 1)
+                ->addAttribute('name', 1)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->uncheckedValue('0')
+                ->render(),
+            'Non-string identifiers must not be transferred to item inputs.',
+        );
+    }
+
+    public function testRenderWithRemoveAriaAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addAriaAttribute('label', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->removeAriaAttribute('label')
+                ->render(),
+            'ARIA attribute must be removed.',
+        );
+    }
+
+    public function testRenderWithRemoveAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addAttribute('class', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->removeAttribute('class')
+                ->render(),
+            'Attribute must be removed.',
+        );
+    }
+
+    public function testRenderWithRemoveDataAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addDataAttribute('value', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->removeDataAttribute('value')
+                ->render(),
+            'Data attribute must be removed.',
+        );
+    }
+
+    public function testRenderWithRemoveEvent(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addEvent('click', "alert('Clicked!')")
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->removeEvent('click')
+                ->render(),
+            'Event handler must be removed.',
+        );
+    }
+
+    public function testRenderWithRole(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div role="banner">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->role('banner')
+                ->render(),
+            "'role' must be serialized.",
+        );
+    }
+
+    public function testRenderWithRoleUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div role="banner">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->role(Role::BANNER)
+                ->render(),
+            "'role' must be serialized.",
+        );
+    }
+
+    public function testRenderWithSetAttribute(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addAttribute('class', 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Arbitrary attribute must be added.',
+        );
+    }
+
+    public function testRenderWithSetAttributeUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div title="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addAttribute(GlobalAttribute::TITLE, 'value')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Arbitrary attribute must be added.',
+        );
+    }
+
+    public function testRenderWithSpellcheck(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div spellcheck="true">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->spellcheck(true)
+                ->render(),
+            "'spellcheck' must be serialized.",
+        );
+    }
+
+    public function testRenderWithStyle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div style='value'>
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->style('value')
+                ->render(),
+            "'style' must be serialized.",
+        );
+    }
+
+    public function testRenderWithTabindex(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div tabindex="3">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->tabIndex(3)
+                ->render(),
+            "'tabindex' must be serialized.",
+        );
+    }
+
+    public function testRenderWithThemeProvider(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div class="text-muted">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->addThemeProvider('muted', DefaultThemeProvider::class)
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->render(),
+            'Theme provider must contribute classes.',
+        );
+    }
+
+    public function testRenderWithTitle(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div title="value">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->title('value')
+                ->render(),
+            "'title' must be serialized.",
+        );
+    }
+
+    public function testRenderWithToString(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div>
+            </div>
+            HTML,
+            (string) RadioList::tag(),
+            'Casting to string must produce HTML.',
+        );
+    }
+
+    public function testRenderWithTranslate(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div translate="no">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->translate(false)
+                ->render(),
+            "'translate' must be serialized.",
+        );
+    }
+
+    public function testRenderWithTranslateUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div translate="no">
+            <input type="radio" value="1">
+            <label>One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->translate(Translate::NO)
+                ->render(),
+            "'translate' must be serialized.",
+        );
+    }
+
+    public function testRenderWithUncheckedValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input name="choice" type="hidden" value="0">
+            <input id="choices-0" name="choice" type="radio" value="1">
+            <label for="choices-0">One</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->id('choices')
+                ->items(ChoiceItem::tag()->label('One')->value(1))
+                ->name('choice')
+                ->uncheckedValue('0')
+                ->render(),
+            'Unchecked value must render a hidden input before the items.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingAttribute(): void
+    {
+        $radioList = RadioList::tag();
+
+        self::assertNotSame(
+            $radioList,
+            $radioList->checked(null),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $radioList,
+            $radioList->enclosedByLabel(),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $radioList,
+            $radioList->itemAttributes([]),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $radioList,
+            $radioList->items(ChoiceItem::tag()),
+            'New instance must be returned (immutability).',
+        );
+        self::assertNotSame(
+            $radioList,
+            $radioList->uncheckedValue(null),
+            'New instance must be returned (immutability).',
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingContentEditable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::CONTENTEDITABLE->value,
+                implode("', '", Enum::normalizeStringArray(ContentEditable::cases())),
+            ),
+        );
+
+        RadioList::tag()->contentEditable('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingDir(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::DIR->value,
+                implode("', '", Enum::normalizeStringArray(Direction::cases())),
+            ),
+        );
+
+        RadioList::tag()->dir('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingDraggable(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::DRAGGABLE->value,
+                implode("', '", Enum::normalizeStringArray(Draggable::cases())),
+            ),
+        );
+
+        RadioList::tag()->draggable('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingLang(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::LANG->value,
+                implode("', '", Enum::normalizeStringArray(Language::cases())),
+            ),
+        );
+
+        RadioList::tag()->lang('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingRole(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::ROLE->value,
+                implode("', '", Enum::normalizeStringArray(Role::cases())),
+            ),
+        );
+
+        RadioList::tag()->role('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingTabindex(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            \UIAwesome\Html\Attribute\Exception\Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                '-2',
+                GlobalAttribute::TABINDEX->value,
+                'value >= -1',
+            ),
+        );
+
+        RadioList::tag()->tabIndex(-2);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSettingTranslate(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::VALUE_NOT_IN_LIST->getMessage(
+                'invalid-value',
+                GlobalAttribute::TRANSLATE->value,
+                implode("', '", Enum::normalizeStringArray(Translate::cases())),
+            ),
+        );
+
+        RadioList::tag()->translate('invalid-value');
+    }
+}

--- a/tests/Form/RadioListTest.php
+++ b/tests/Form/RadioListTest.php
@@ -283,6 +283,102 @@ final class RadioListTest extends TestCase
         );
     }
 
+    public function testRenderWithCheckedFalse(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice" type="radio" value="1">
+            <label for="choices-0">One</label>
+            <input id="choices-1" name="choice" type="radio" value="2">
+            <label for="choices-1">Two</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->checked(false)
+                ->id('choices')
+                ->items(
+                    ChoiceItem::tag()->label('One')->value(1),
+                    ChoiceItem::tag()->label('Two')->value(2),
+                )
+                ->name('choice')
+                ->render(),
+            'No item must be checked.',
+        );
+    }
+
+    public function testRenderWithCheckedNull(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice" type="radio" value="1">
+            <label for="choices-0">One</label>
+            <input id="choices-1" name="choice" type="radio" value="2">
+            <label for="choices-1">Two</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->checked(null)
+                ->id('choices')
+                ->items(
+                    ChoiceItem::tag()->label('One')->value(1),
+                    ChoiceItem::tag()->label('Two')->value(2),
+                )
+                ->name('choice')
+                ->render(),
+            'No item must be checked.',
+        );
+    }
+
+    public function testRenderWithCheckedTrue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice" type="radio" value="1" checked>
+            <label for="choices-0">One</label>
+            <input id="choices-1" name="choice" type="radio" value="2" checked>
+            <label for="choices-1">Two</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->checked(true)
+                ->id('choices')
+                ->items(
+                    ChoiceItem::tag()->label('One')->value(1),
+                    ChoiceItem::tag()->label('Two')->value(2),
+                )
+                ->name('choice')
+                ->render(),
+            'Every item must be checked.',
+        );
+    }
+
+    public function testRenderWithCheckedUsingArray(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <div id="choices">
+            <input id="choices-0" name="choice" type="radio" value="1" checked>
+            <label for="choices-0">One</label>
+            <input id="choices-1" name="choice" type="radio" value="2">
+            <label for="choices-1">Two</label>
+            </div>
+            HTML,
+            RadioList::tag()
+                ->checked([1])
+                ->id('choices')
+                ->items(
+                    ChoiceItem::tag()->label('One')->value(1),
+                    ChoiceItem::tag()->label('Two')->value(2),
+                )
+                ->name('choice')
+                ->render(),
+            'Matching item must be checked.',
+        );
+    }
+
     public function testRenderWithCheckedUsingEnum(): void
     {
         self::assertSame(
@@ -298,7 +394,7 @@ final class RadioListTest extends TestCase
                 ->items(ChoiceItem::tag()->label('Value')->value('value'))
                 ->name('choice')
                 ->render(),
-            'Enum value must check its normalized item value.',
+            'Matching item must be checked.',
         );
     }
 

--- a/tests/Form/SelectTest.php
+++ b/tests/Form/SelectTest.php
@@ -21,7 +21,6 @@ use UIAwesome\Html\Attribute\Values\{
     Role,
     Translate,
 };
-use UIAwesome\Html\Contracts\Form\FormControlInterface;
 use UIAwesome\Html\Form\{Optgroup, Option, Select};
 use UIAwesome\Html\Helper\Enum;
 use UIAwesome\Html\Helper\Exception\Message;
@@ -76,15 +75,6 @@ final class SelectTest extends TestCase
                 ->html('<value>')
                 ->render(),
             'Raw HTML content must be applied.',
-        );
-    }
-
-    public function testImplementsFormControlInterface(): void
-    {
-        self::assertInstanceOf(
-            FormControlInterface::class,
-            Select::tag(),
-            'Select must satisfy the form control contract.',
         );
     }
 
@@ -562,6 +552,25 @@ final class SelectTest extends TestCase
         );
     }
 
+    public function testRenderWithMultipleAndNullValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select multiple>
+            <option value="dog">
+            Dog
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->multiple(true)
+                ->option(Option::tag()->selected(true)->value('dog')->content('Dog'))
+                ->value(null)
+                ->render(),
+            '`null` must clear the selection instead of failing the array constraint.',
+        );
+    }
+
     public function testRenderWithName(): void
     {
         self::assertSame(
@@ -616,6 +625,26 @@ final class SelectTest extends TestCase
         );
     }
 
+    public function testRenderWithOptionPreservesContentOrder(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            Before<option value="1">
+            Santiago
+            </option>
+            After
+            </select>
+            HTML,
+            Select::tag()
+                ->content('Before')
+                ->option(Option::tag()->value('1')->content('Santiago'))
+                ->content('After')
+                ->render(),
+            'Option must preserve its position relative to other content.',
+        );
+    }
+
     public function testRenderWithOptions(): void
     {
         self::assertSame(
@@ -633,9 +662,30 @@ final class SelectTest extends TestCase
             </select>
             HTML,
             Select::tag()
-                ->options(['dog', 'Dog'], ['cat', 'Cat'], ['hamster', 'Hamster'])
+                ->options(
+                    Option::tag()->value('dog')->content('Dog'),
+                    Option::tag()->value('cat')->content('Cat'),
+                    Option::tag()->value('hamster')->content('Hamster'),
+                )
                 ->render(),
             'Options collection must be applied.',
+        );
+    }
+
+    public function testRenderWithoutValuePreservesOptionSelection(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option value="dog" selected>
+            Dog
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->option(Option::tag()->selected(true)->value('dog')->content('Dog'))
+                ->render(),
+            'Option-level selection must be preserved when select value is not configured.',
         );
     }
 
@@ -738,6 +788,149 @@ final class SelectTest extends TestCase
                 ->role(Role::BANNER)
                 ->render(),
             "'role' must be serialized.",
+        );
+    }
+
+    public function testRenderWithSelectedValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option value="dog">
+            Dog
+            </option>
+            <option value="cat" selected>
+            Cat
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->options(
+                    Option::tag()->value('dog')->content('Dog'),
+                    Option::tag()->value('cat')->content('Cat'),
+                )
+                ->value('cat')
+                ->render(),
+            'Selected value must mark the matching option.',
+        );
+    }
+
+    public function testRenderWithSelectedValueClearsExistingSelection(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option value="dog">
+            Dog
+            </option>
+            <option value="cat" selected>
+            Cat
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->options(
+                    Option::tag()->selected(true)->value('dog')->content('Dog'),
+                    Option::tag()->value('cat')->content('Cat'),
+                )
+                ->value('cat')
+                ->render(),
+            'Configured value must replace option-level selection.',
+        );
+    }
+
+    public function testRenderWithSelectedValueInOptgroup(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <optgroup label="Pets">
+            <option value="dog">
+            Dog
+            </option>
+            <option value="cat" selected>
+            Cat
+            </option>
+            </optgroup>
+            </select>
+            HTML,
+            Select::tag()
+                ->optgroup(
+                    Optgroup::tag()
+                        ->label('Pets')
+                        ->options(
+                            Option::tag()->value('dog')->content('Dog'),
+                            Option::tag()->value('cat')->content('Cat'),
+                        ),
+                )
+                ->value('cat')
+                ->render(),
+            'Selected value must be applied to grouped options.',
+        );
+    }
+
+    public function testRenderWithSelectedValuePreservesOptionValue(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option value="yes">
+            Yes
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->option(Option::tag()->value('yes')->content('Yes'))
+                ->value('no')
+                ->render(),
+            'Selected value must not overwrite the submitted option value.',
+        );
+    }
+
+    public function testRenderWithSelectedValues(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select multiple>
+            <option value="1" selected>
+            One
+            </option>
+            <option value="2">
+            Two
+            </option>
+            <option value="3" selected>
+            Three
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->multiple(true)
+                ->options(
+                    Option::tag()->value(1)->content('One'),
+                    Option::tag()->value(2)->content('Two'),
+                    Option::tag()->value(3)->content('Three'),
+                )
+                ->value(['1', 3])
+                ->render(),
+            'Multiple selected values must mark every matching option.',
+        );
+    }
+
+    public function testRenderWithSelectedValueUsingEnum(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option value="value" selected>
+            Value
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->option(Option::tag()->value('value')->content('Value'))
+                ->value(BackedString::VALUE)
+                ->render(),
+            'Enum value must select its normalized option value.',
         );
     }
 
@@ -907,6 +1100,30 @@ final class SelectTest extends TestCase
         );
     }
 
+    public function testRenderWithValueNullClearsExistingSelection(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option value="dog">
+            Dog
+            </option>
+            <option value="null">
+            Null
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->options(
+                    Option::tag()->selected(true)->value('dog')->content('Dog'),
+                    Option::tag()->selected(true)->value('null')->content('Null'),
+                )
+                ->value(null)
+                ->render(),
+            'Null selected value must clear option-level selection.',
+        );
+    }
+
     public function testReturnNewInstanceWhenSettingAttribute(): void
     {
         $select = Select::tag();
@@ -923,9 +1140,24 @@ final class SelectTest extends TestCase
         );
         self::assertNotSame(
             $select,
-            $select->options(['dog', 'Dog']),
+            $select->options(Option::tag()->value('dog')->content('Dog')),
             'New instance must be returned (immutability).',
         );
+        self::assertNotSame(
+            $select,
+            $select->value('dog'),
+            'New instance must be returned (immutability).',
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenMultipleValueIsScalar(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Invalid value \'dog\' for attribute \'value\'. Expected: \'array when "multiple" is true\'.',
+        );
+
+        Select::tag()->multiple(true)->value('dog')->render();
     }
 
     public function testThrowInvalidArgumentExceptionWhenSettingContentEditable(): void

--- a/tests/Form/SelectTest.php
+++ b/tests/Form/SelectTest.php
@@ -870,6 +870,102 @@ final class SelectTest extends TestCase
         );
     }
 
+    public function testRenderWithSelectedValueMatchingOptionText(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option selected>
+            Dog
+            </option>
+            <option>
+            Cat
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->options(
+                    Option::tag()->content('Dog'),
+                    Option::tag()->content('Cat'),
+                )
+                ->value('Dog')
+                ->render(),
+            'Option without a `value` attribute must match on its submitted text.',
+        );
+    }
+
+    public function testRenderWithSelectedValueMatchingOptionTextCollapsingWhitespace(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option selected>
+            \tDog\r\n and\f  Cat\x20
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->option(Option::tag()->html("\tDog\r\n and\f  Cat "))
+                ->value('Dog and Cat')
+                ->render(),
+            'ASCII whitespace must be stripped and collapsed before matching.',
+        );
+    }
+
+    public function testRenderWithSelectedValueMatchingOptionTextContainingEntity(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option selected>
+            Dog &amp; Cat
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->option(Option::tag()->content('Dog & Cat'))
+                ->value('Dog & Cat')
+                ->render(),
+            'Encoded text must be decoded before matching.',
+        );
+    }
+
+    public function testRenderWithSelectedValueMatchingOptionTextContainingQuoteEntity(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option selected>
+            Dog &apos;n Cat
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->option(Option::tag()->html('Dog &apos;n Cat'))
+                ->value("Dog 'n Cat")
+                ->render(),
+            'HTML5 quote entities must be decoded before matching.',
+        );
+    }
+
+    public function testRenderWithSelectedValueMatchingOptionTextIgnoringMarkup(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option selected>
+            <b>Dog</b>
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->option(Option::tag()->html('<b>Dog</b>'))
+                ->value('Dog')
+                ->render(),
+            'Markup must be excluded from the matched text.',
+        );
+    }
+
     public function testRenderWithSelectedValuePreservesOptionValue(): void
     {
         self::assertSame(

--- a/tests/Form/SelectTest.php
+++ b/tests/Form/SelectTest.php
@@ -16,6 +16,7 @@ use UIAwesome\Html\Attribute\Values\{
     Data,
     Direction,
     Draggable,
+    ElementAttribute,
     GlobalAttribute,
     Language,
     Role,
@@ -930,7 +931,7 @@ final class SelectTest extends TestCase
                 ->option(Option::tag()->value('value')->content('Value'))
                 ->value(BackedString::VALUE)
                 ->render(),
-            'Enum value must select its normalized option value.',
+            'Selected value must mark the matching option.',
         );
     }
 
@@ -1154,7 +1155,11 @@ final class SelectTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Invalid value \'dog\' for attribute \'value\'. Expected: \'array when "multiple" is true\'.',
+            \UIAwesome\Html\Attribute\Exception\Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                'dog',
+                ElementAttribute::VALUE->value,
+                'array when "multiple" is true',
+            ),
         );
 
         Select::tag()->multiple(true)->value('dog')->render();

--- a/tests/Form/SelectTest.php
+++ b/tests/Form/SelectTest.php
@@ -816,6 +816,30 @@ final class SelectTest extends TestCase
         );
     }
 
+    public function testRenderWithSelectedValueAsSingleElementArray(): void
+    {
+        self::assertSame(
+            <<<HTML
+            <select>
+            <option value="dog">
+            Dog
+            </option>
+            <option value="cat" selected>
+            Cat
+            </option>
+            </select>
+            HTML,
+            Select::tag()
+                ->options(
+                    Option::tag()->value('dog')->content('Dog'),
+                    Option::tag()->value('cat')->content('Cat'),
+                )
+                ->value(['cat'])
+                ->render(),
+            'A single-element array must be accepted without `multiple`.',
+        );
+    }
+
     public function testRenderWithSelectedValueClearsExistingSelection(): void
     {
         self::assertSame(
@@ -1371,5 +1395,19 @@ final class SelectTest extends TestCase
         );
 
         Select::tag()->translate('invalid-value');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenSingleValueHasMoreThanOneValue(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            \UIAwesome\Html\Attribute\Exception\Message::ATTRIBUTE_INVALID_VALUE->getMessage(
+                'dog, cat',
+                ElementAttribute::VALUE->value,
+                'single value unless "multiple" is true',
+            ),
+        );
+
+        Select::tag()->value(['dog', 'cat'])->render();
     }
 }

--- a/tests/Form/TextAreaTest.php
+++ b/tests/Form/TextAreaTest.php
@@ -22,7 +22,6 @@ use UIAwesome\Html\Attribute\Values\{
     Translate,
 };
 use UIAwesome\Html\Attribute\Values\{Autocapitalize, Autocorrect};
-use UIAwesome\Html\Contracts\Form\FormControlInterface;
 use UIAwesome\Html\Form\TextArea;
 use UIAwesome\Html\Form\Values\Wrap;
 use UIAwesome\Html\Helper\Enum;
@@ -78,15 +77,6 @@ final class TextAreaTest extends TestCase
                 ->html('<value>')
                 ->render(),
             'Raw HTML content must be applied.',
-        );
-    }
-
-    public function testImplementsFormControlInterface(): void
-    {
-        self::assertInstanceOf(
-            FormControlInterface::class,
-            TextArea::tag(),
-            'TextArea must satisfy the form control contract.',
         );
     }
 

--- a/tests/Provider/Form/CheckedProvider.php
+++ b/tests/Provider/Form/CheckedProvider.php
@@ -292,6 +292,28 @@ final class CheckedProvider
                 <input id="inputcheckbox" type="checkbox" value="other">
                 HTML,
             ],
+            // default submitted value (`on`) when the element has no `value` attribute
+            'checked: "on", value: null' => [
+                'on',
+                null,
+                <<<HTML
+                <input id="inputcheckbox" type="checkbox" checked>
+                HTML,
+            ],
+            'checked: ["on"], value: null' => [
+                ['on'],
+                null,
+                <<<HTML
+                <input id="inputcheckbox" type="checkbox" checked>
+                HTML,
+            ],
+            'checked: "other", value: null' => [
+                'other',
+                null,
+                <<<HTML
+                <input id="inputcheckbox" type="checkbox">
+                HTML,
+            ],
         ];
     }
 }


### PR DESCRIPTION
# Pull Request

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] CI/build configuration
- [ ] Documentation update
- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Reference related issues: Fixes #123, Closes #456 -->
